### PR TITLE
Add minutes to the time in the scormcontenthandler for the Plugin.

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -115,7 +115,7 @@ class ScormCloudContentHandler
 	                        "<td class='$completion'>".$completion."</td>" .
 	                        "<td class='$success'>".$success."</td>" .
 	                        "<td class='".($score == "unknown" ? __("unknown") : "")."'>".($score == "unknown" ? "-" : $score."%")."</td>".
-	                        "<td class='time'>$seconds ".__("secs","scormcloud")."</td>" .
+                            "<td class='time'>".floor($seconds / 60)."min ".($seconds % 60).__('sec spent in course',"scormcloud")."</td>".
 	                        "</tr></table>";
     
     


### PR DESCRIPTION
Add minutes to the time in the scormcontenthandler for the Plugin. We've gotten a number of questions where people are unhappy that this shows seconds (All other times in plugin are minutes). This uses the same minute code as the rest of the plugin. This change is now deployed in 3 users WP sites.
