### PR TITLE
pushing blank profile data into SCORMCloud generates a stack trace

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -203,7 +203,13 @@ class ScormCloudContentHandler
         $ScormService = ScormCloudPlugin::get_cloud_service();
         $regService = $ScormService->getRegistrationService();
         $userData = get_userdata($userId);
-        $response = $regService->UpdateLearnerInfo($userData->user_email,$userData->user_firstname,$userData->user_lastname);
-        write_log($response);
+		/* pushing blank data into SCORMCloud generates a stack trace */
+		if (!empty($userData->user_firstname) &&
+			!empty($userData->user_lastname)) {
+		  $response = $regService->UpdateLearnerInfo($userData->user_email,$userData->user_firstname,$userData->user_lastname);
+		  write_log($response);
+		} else {
+		  write_log("profile update skipped for {$userData->user_email} due to missing first or last name");
+		}
     }
 }


### PR DESCRIPTION
note: no version # increment as current version here https://wordpress.org/plugins/scormcloud/
is 1.1.8, but here

https://github.com/RusticiSoftware/SCORMCloud_WordPressPlugin/blob/master/scormcloud/scormcloud.php#L7

it says 1.1.7

l
