### PR TITLE
made regex for shortcodes less greedy - fixes Cloud-407

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -8,7 +8,7 @@ class ScormCloudContentHandler
     public static function make_blog_entry($content){
         global $wpdb;
         
-        preg_match_all('/\[scormcloud.training:.*\]/',$content,$cloudTagArray);
+        preg_match_all('/\\[scormcloud.training:.*?\\]/',$content,$cloudTagArray);
     
         $cloudTags = $cloudTagArray[0];
     
@@ -140,7 +140,7 @@ class ScormCloudContentHandler
             $content = str_replace($tagString,$inviteHtml,$content);
         }
 
-		preg_match_all('/\[scormcloud.reportage:.*]/',$content,$cloudRepArray);
+		preg_match_all('/\\[scormcloud.reportage:.*?\\]/',$content,$cloudRepArray);
     
         $cloudReportageLinks = $cloudRepArray[0];
     


### PR DESCRIPTION
The regex to find and parse the shortcodes was too greedy.  Therefore if a user put two SCORM Cloud generated shortcodes next to each other without a space it would throw an error.   I believe that Joe made an issue for it in Jira, Cloud-407