### PR TITLE
Cleaning up enqueue calls for css and javascript

### DIFF
--- a/scormcloud/admin/managecourses.php
+++ b/scormcloud/admin/managecourses.php
@@ -25,7 +25,7 @@ if ($isValidAccount){
     ?>
 <div id="UploadFrame"><iframe width="100%" height="50px"
 	style="border: 0;"
-	src="<?php echo get_option( 'siteurl' ); ?>/wp-content/plugins/scormcloud/uploadpif.php?id=<?php echo $packageid; ?>"
+	src="<?php echo site_url(); ?>/wp-content/plugins/scormcloud/uploadpif.php?id=<?php echo $packageid; ?>"
 	id="ifmImport"></iframe></div>
 
     <?php
@@ -58,17 +58,17 @@ if ($isValidAccount){
 	foreach($courseObjArray as $course)
 	{
 	    echo "<tr key='".$course->getCourseId()."' class='courseRow'><td class='title'>";
-	    echo $course->getTitle()."<a key='".$course->getCourseId()."' class='previewLink' onclick='scormcloud_LaunchCoursePreview(\"".$course->getCourseId()."\",\"".get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php\",window.location);' href='javascript:void(0);'>".__("Preview","scormcloud")."</a>";
+	    echo $course->getTitle()."<a key='".$course->getCourseId()."' class='previewLink' onclick='scormcloud_LaunchCoursePreview(\"".$course->getCourseId()."\",\"".site_url() . "/wp-content/plugins/scormcloud/ajax.php\",window.location);' href='javascript:void(0);'>".__("Preview","scormcloud")."</a>";
 	    echo '</td><td>';
 	    $regCount = $course->getNumberOfRegistrations();
 	    echo "$regCount ".($regCount != 1 ? __("Learners","scormcloud") : __("Learner","scormcloud"));
 	    echo '</td><td>';
-	    echo "<a key='".$course->getCourseId()."' class='reportLink' onclick='scormcloud_LaunchCourseReport(\"".$course->getCourseId()."\",\"".get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php\");' href='javascript:void(0);'>".__("View Course Report","scormcloud")."</a>";
+	    echo "<a key='".$course->getCourseId()."' class='reportLink' onclick='scormcloud_LaunchCourseReport(\"".$course->getCourseId()."\",\"".site_url() . "/wp-content/plugins/scormcloud/ajax.php\");' href='javascript:void(0);'>".__("View Course Report","scormcloud")."</a>";
 	    echo '</td>';
 	    echo "<td><a href='#' key='".$course->getCourseId()."' class='viewPkgPropsLink' >".__("Edit Course Properties","scormcloud")."</a></td>";
 	    echo '<td>';
 	    if (strpos($course->getCourseId(),$GLOBALS['blog_id']."-") === 0){
-	        echo "<a key='".$course->getCourseId()."' class='deleteLink' onclick='scormcloud_deleteCourse(\"".$course->getCourseId()."\",\"".get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php\");'  >".__("Delete Course","scormcloud")."</a>";
+	        echo "<a key='".$course->getCourseId()."' class='deleteLink' onclick='scormcloud_deleteCourse(\"".$course->getCourseId()."\",\"".site_url() . "/wp-content/plugins/scormcloud/ajax.php\");'  >".__("Delete Course","scormcloud")."</a>";
 	    }
 	    echo '</td></tr>';
 	    echo "<tr class='propseditor' key='".$course->getCourseId()."' ><td class='regList' colspan='5'><iframe src=''></iframe></td></tr>";
@@ -81,7 +81,7 @@ jQuery('.viewPkgPropsLink').toggle(function(){
     if (jQuery('tr.propseditor[key="'+ courseid + '"] iframe').attr('src') == ''){
         jQuery.ajax({
             type: "POST",
-            url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+            url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
             data: 	"action=getPropertiesEditorUrl" +
                     "&courseid=" + courseid,
             success: function(data){
@@ -110,7 +110,7 @@ function(){
     echo "<div>
             <h2>".__("Please configure your SCORM Cloud settings to view your courses.","scormcloud")."</h2>
         </div>";
-    echo '<div class="settingsPageLink"><a href="'.get_option( 'siteurl' ).'/wp-admin/admin.php?page=scormcloudsettings"
+    echo '<div class="settingsPageLink"><a href="'.site_url().'/wp-admin/admin.php?page=scormcloudsettings"
 				title="'.__("Click here to configure your SCORM Cloud plugin.","scormcloud").'">'.__("Click Here to go to the settings page.","scormcloud").'</a></div>';
 }
 

--- a/scormcloud/admin/managetraining.php
+++ b/scormcloud/admin/managetraining.php
@@ -202,7 +202,7 @@ jQuery("#btnAddRegistration").click(function(){
 	
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	dataString,
         success: function(rspStr){
             if (rspStr == 'success'){
@@ -221,7 +221,7 @@ jQuery("#btnAddRegistration").click(function(){
         echo "<div>
             <h3>".__("Please configure your SCORM Cloud settings to add registrations.","scormcloud")."</h3>
         </div>";
-        echo '<div class="settingsPageLink"><a href="'.get_option( 'siteurl' ).'/wp-admin/admin.php?page=scormcloudsettings"
+        echo '<div class="settingsPageLink"><a href="'.site_url().'/wp-admin/admin.php?page=scormcloudsettings"
 				title="'.__("Click here to configure your SCORM Cloud plugin.","scormcloud").'">'.__("Click Here to go to the settings page.","scormcloud").'</a></div>';
 
     }
@@ -252,7 +252,7 @@ jQuery("#btnAddRegistration").click(function(){
     {
 
         echo "<tr class='regRow' key='".$invite->invite_id."'>";
-        echo "<td class='title'><a title='".__("Click to view details of this invitation.","scormcloud")."' href='".get_option( 'siteurl' )."/wp-admin/admin.php?page=scormcloud/manage_training&inviteid=".$invite->invite_id."'>".__($invite->course_title)."</a></td>";
+        echo "<td class='title'><a title='".__("Click to view details of this invitation.","scormcloud")."' href='".site_url()."/wp-admin/admin.php?page=scormcloud/manage_training&inviteid=".$invite->invite_id."'>".__($invite->course_title)."</a></td>";
 
         if ($invite->post_id == "__direct_invite__"){
             echo "<td>".__("User Invitation","scormcloud")."</td>";
@@ -263,7 +263,7 @@ jQuery("#btnAddRegistration").click(function(){
         } else {
             $postInfo = get_post($invite->post_id);
             if ($postInfo != null){
-                echo "<td><a title='".__('Click to edit this post.',"scormcloud")."' href='".get_option( 'siteurl' )."/wp-admin/post.php?action=edit&post=".$invite->post_id."'>".$postInfo->post_title."</a></td>";
+                echo "<td><a title='".__('Click to edit this post.',"scormcloud")."' href='".site_url()."/wp-admin/post.php?action=edit&post=".$invite->post_id."'>".$postInfo->post_title."</a></td>";
                 echo "<td><span class='localizeDate' format= 'mmmm d, yyyy h:MM TT' utcdate='".date("d M Y H:i:s", strtotime($postInfo->post_date))."'>".$postInfo->post_date."</span></td>";
             } else {
                 echo "<td>".__("","scormcloud")."</td>";
@@ -301,7 +301,7 @@ jQuery(".viewReportageLink").click(function(){
      
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=getInviteReportUrl" +
                 "&inviteid=" + invId,
         success: function(url){
@@ -322,7 +322,7 @@ jQuery('.viewRegsLink').toggle(function(){
     if (jQuery('tr.regList[key="'+ invId + '"]').length < 1){
         jQuery.ajax({
             type: "POST",
-            url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+            url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
             data: 	"action=getRegistrations" +
                     "&inviteid=" + invId,
             success: function(data){
@@ -351,7 +351,7 @@ jQuery('.activateLink').click(function(){
     
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=setactive" +
                 "&inviteid=" + invId +
                 "&active=" + (wasActive ? '0' : '1'),
@@ -377,7 +377,7 @@ function Scormcloud_loadRegReport(invId,regId){
                     
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=getRegReportUrl" +
                 "&inviteid=" + invId +
                 "&regid=" + regId,

--- a/scormcloud/admin/scormcloudadminui.php
+++ b/scormcloud/admin/scormcloudadminui.php
@@ -16,9 +16,9 @@ class ScormCloudAdminUi {
 	 * Enqueue all of the admin includes.
 	 */
 	public static function enqueue_admin_includes() {
-		wp_enqueue_script( 'scormcloud-admin', plugins_url( '/scormcloud/scripts/scormcloud.admin.js', __FILE__ ) );
-		wp_enqueue_script( 'scormcloud-date_format', plugins_url( '/scormcloud/scripts/date.format.js', __FILE__ ) );
-		wp_register_style( 'scormcloud-admin-style', plugins_url( '/scormcloud/css/scormcloud.admin.css', __FILE__ ) );
+		wp_enqueue_script( 'scormcloud-admin', plugins_url( '../scripts/scormcloud.admin.js', __FILE__ ) );
+		wp_enqueue_script( 'scormcloud-date_format', plugins_url( '../scripts/date.format.js', __FILE__ ) );
+		wp_register_style( 'scormcloud-admin-style', plugins_url( '../css/scormcloud.admin.css', __FILE__ ) );
 		wp_enqueue_style( 'scormcloud-admin-style' );
 	}
 
@@ -111,11 +111,9 @@ class ScormCloudAdminUi {
 	public static function set_js_vars() {
 		?>
 		<script type="text/javascript" charset="utf-8">
-			// <![CDATA[
 			if (typeof ScormCloud !== 'undefined' && typeof ScormCloud.Dialog !== 'undefined') {
-                ScormCloud.Dialog.embedTrainingUrl = "<?php echo plugins_url( '/scormcloud/ui/embedtrainingdialog.php' ); ?>";
+				ScormCloud.Dialog.embedTrainingUrl = "<?php echo esc_url_raw( plugins_url( '/scormcloud/ui/embedtrainingdialog.php' ) ); ?>";
 			}
-			// ]]>
 		</script>
 		<?php
 	}
@@ -133,7 +131,7 @@ class ScormCloudAdminUi {
 		if ( in_array( $screen_id, $plugin_hooks ) ) {
 
 			$help_html = "<div class='sc_helpPanel'>";
-			$help_html .= "<h2>SCORM Cloud Hints and Tips</h2>";
+			$help_html .= '<h2>SCORM Cloud Hints and Tips</h2>';
 
 			if ( isset( $_GET[ 'page' ] ) ) {
 				$plugin_page = stripslashes( $_GET[ 'page' ] );
@@ -144,8 +142,8 @@ class ScormCloudAdminUi {
 
 				case 'scormcloud/network-admin':
 				case 'scormcloud/admin':
-					$help_html .= "<p><span class='emph'>Overall Reportage Summary</span> is a results report for all trainings in your wordpress plugin."
-    	            $help_html .= "Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'Scorm Cloud Reportage' link under the page header.";
+					$help_html .= "<p><span class='emph'>Overall Reportage Summary</span> is a results report for all trainings in your wordpress plugin.";
+					$help_html .= "Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'Scorm Cloud Reportage' link under the page header.";
 					$help_html .= '</p>';
 					break;
 
@@ -212,7 +210,7 @@ class ScormCloudAdminUi {
 					break;
 
 
-			}
+			} // End switch().
 
 			$help_html .= "<hr>";
 

--- a/scormcloud/admin/scormcloudadminui.php
+++ b/scormcloud/admin/scormcloudadminui.php
@@ -10,66 +10,68 @@ class ScormCloudAdminUi
         add_action('network_admin_menu', array(__CLASS__, 'network_admin_menu_actions'));
         add_action('admin_head', array(__CLASS__, 'set_js_vars'));
     }
-    
-    public static function enqueue_admin_includes()
-    {
-        wp_enqueue_script('scormcloud-admin', plugins_url('/scormcloud/scripts/scormcloud.admin.js'), array());
-        wp_enqueue_script('scormcloud-date_format', plugins_url('/scormcloud/scripts/date.format.js'), array());
-        wp_register_style('scormcloud-admin-style', plugins_url('/scormcloud/css/scormcloud.admin.css'));
-        wp_enqueue_style('scormcloud-admin-style');
-    }
-    
+
+	/**
+	 * Enqueue all of the admin includes.
+	 */
+	public static function enqueue_admin_includes() {
+		wp_enqueue_script( 'scormcloud-admin', plugins_url( '/scormcloud/scripts/scormcloud.admin.js', __FILE__ ) );
+		wp_enqueue_script( 'scormcloud-date_format', plugins_url( '/scormcloud/scripts/date.format.js', __FILE__ ) );
+		wp_register_style( 'scormcloud-admin-style', plugins_url( '/scormcloud/css/scormcloud.admin.css', __FILE__ ) );
+		wp_enqueue_style( 'scormcloud-admin-style' );
+	}
+
     public static function admin_menu_actions()
     {
         self::enqueue_admin_includes();
-    
+
         $topslug = 'scormcloud/admin';
         $plugin_hooks =& ScormCloudPlugin::$hooks;
         $plugin_hooks[] = add_menu_page('SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, array(__CLASS__, 'show_start_page'));
         $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Courses', 'Courses', 'publish_posts', 'scormcloud/manage_courses', array(__CLASS__, 'show_manage_courses'));
         $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Training', 'Training', 'publish_posts', 'scormcloud/manage_training', array(__CLASS__, 'show_manage_training'));
         $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/admin/settings', array(__CLASS__, 'show_settings'));
-        
+
         add_action('contextual_help', array(__CLASS__, 'contextual_help'), 10, 3);
     }
-    
+
     public static function network_admin_menu_actions()
     {
         self::enqueue_admin_includes();
-    
+
         $topslug = 'scormcloud/network-admin';
         $plugin_hooks =& ScormCloudPlugin::$hooks;
         $plugin_hooks[] = add_menu_page('SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, array(__CLASS__, 'show_start_page'));
         $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/network-admin/settings', array(__CLASS__, 'show_network_settings'));
-        
+
         add_action('contextual_help', array(__CLASS__, 'contextual_help'), 10, 3);
     }
-    
+
     public static function show_start_page()
     {
         include('startpage.php');
     }
-    
+
     public static function show_manage_courses()
     {
         include('managecourses.php');
     }
-    
+
     public static function show_manage_training()
     {
         include('managetraining.php');
     }
-    
+
     public static function show_settings()
     {
         include('settings.php');
     }
-    
+
     public static function show_network_settings()
     {
         include('network_settings.php');
     }
-    
+
     public static function set_js_vars()
     {
         ?>
@@ -77,41 +79,41 @@ class ScormCloudAdminUi
     // <![CDATA[
     	if (typeof ScormCloud !== 'undefined' && typeof ScormCloud.Dialog !== 'undefined') {
             var dialogUrl = "<?php echo plugins_url('/scormcloud/ui/embedtrainingdialog.php'); ?>";
-            
+
     		ScormCloud.Dialog.embedTrainingUrl = dialogUrl;
     	}
-    // ]]>	
+    // ]]>
     </script>
         <?php
     }
-    
+
     public static function contextual_help($text, $screen_id, $screen)
     {
         $plugin_hooks = ScormCloudPlugin::$hooks;
-        
+
         if (substr($screen_id, -8) == '-network') {
             $screen_id = substr_replace($screen_id, '', -8);
         }
-        
+
         if (in_array($screen_id, $plugin_hooks)){
-    
+
             $helpHtml = "<div class='sc_helpPanel'>";
             $helpHtml .= "<h2>SCORM Cloud Hints and Tips</h2>";
-    
+
             if ( isset($_GET['page']) ) {
                 $plugin_page = stripslashes($_GET['page']);
                 $plugin_page = plugin_basename($plugin_page);
             }
-    
+
             switch ($plugin_page){
-    
+
                 case 'scormcloud/network-admin':
                 case 'scormcloud/admin':
                     $helpHtml .= "<p><span class='emph'>Overall Reportage Summary</span> is a results report for all trainings in your wordpress plugin.
     	            Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'Scorm Cloud Reportage' link under the page header.";
                     $helpHtml .= "</p>";
                     break;
-    
+
                 case 'scormcloud/manage_courses':
                     $helpHtml .= "<p><span class='emph'>Import a new course</span> provides functionality to upload a course to the SCORM Cloud for use in trainings in wordpress.
     	            Files uploaded should be zipped up SCORM or AICC course packages.</p>";
@@ -123,9 +125,9 @@ class ScormCloudAdminUi
     	            will not be deleted.</li>
     	            </ul></p>";
                     break;
-    
+
                 case 'scormcloud/manage_training':
-    
+
                     if (isset($_GET['inviteid'])){
                         $helpHtml .= "<p>Clicking the <span class='emph'>click to activate/deactivate</span> link will set the training as launchable or not launchable.</p>";
                         $helpHtml .= "<p><span class='emph'>Invitation Details</span> provides a way to modify an existing post/page invitation.  An example of what the invitation will
@@ -139,7 +141,7 @@ class ScormCloudAdminUi
     	                </ul>
     	                </p>";
                     } else {
-    
+
                         $helpHtml .= "<p><span class='emph'>Quick Create Training</span> provides the ability to directly assign a course to existing wordpress users.  These trainings will not appear
     	                in a wordpress post or page, but the course will show up in the user's <span class='emph'>SCORM Cloud User Training Widget</span>; so it is important to add that widget to your wordpress blog for the users
     	                to be able to launch the assigned courses.  Note that using this functionality to assign courses pre-creates a registration in your SCORM Cloud account for each assigned course and user.</p>";
@@ -156,34 +158,34 @@ class ScormCloudAdminUi
     	                </p>";
                     }
                     break;
-    
+
                 case 'scormcloud/admin/settings':
                     $helpHtml .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
                     $helpHtml .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
                     $helpHtml .= '<p>The <span class="emph">SCORM Player Stylesheet URL</span> controls the CSS stylesheet used to style the user interface of the SCORM player.</p>';
                     break;
-                    
+
                 case 'scormcloud/network-admin/settings':
                     $helpHtml .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
                     $helpHtml .= '<p><span class="emph">Use same SCORM Cloud account across all sites:</span> If enabled, all sites in the network will use the SCORM Cloud account credentials and Engine URL and administrators for those sites will not be able to change these settings.</p>';
                     $helpHtml .= '<p><span class="emph">Share courses among all sites:</span> If enabled, all sites will use and upload to the same course library on the SCORM Cloud for creating training.</p>';
                     $helpHtml .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
                     break;
-                    
+
                 default:
                     $helpHtml .= "<p><span class='emph'></span></p>";
                     break;
-    
-    
+
+
             }
-    
+
             $helpHtml .= "<hr>";
-    
+
             $helpHtml .= "<p>The SCORM Cloud plugin requires a SCORM Cloud account that can be created and managed on the <a href='https://cloud.scorm.com/'>SCORM Cloud</a> application site.</p>";
             $helpHtml .= "<p>The SCORM Cloud is brought to you by <a href='https://www.scorm.com/'>Rustici Software</a>.</p>";
-    
-    
-    
+
+
+
             $helpHtml .= "</div>";
             return $helpHtml;
         } else {

--- a/scormcloud/admin/scormcloudadminui.php
+++ b/scormcloud/admin/scormcloudadminui.php
@@ -1,15 +1,16 @@
 <?php
 
-require_once(SCORMCLOUD_BASE.'scormcloudplugin.php');
+require_once( SCORMCLOUD_BASE . 'scormcloudplugin.php' );
 
-class ScormCloudAdminUi
-{
-    public static function initialize()
-    {
-        add_action('admin_menu', array(__CLASS__, 'admin_menu_actions'));
-        add_action('network_admin_menu', array(__CLASS__, 'network_admin_menu_actions'));
-        add_action('admin_head', array(__CLASS__, 'set_js_vars'));
-    }
+class ScormCloudAdminUi {
+	/**
+	 * Initialize the admin ui.
+	 */
+	public static function initialize() {
+		add_action( 'admin_menu', [ __CLASS__, 'admin_menu_actions' ] );
+		add_action( 'network_admin_menu', [ __CLASS__, 'network_admin_menu_actions' ] );
+		add_action( 'admin_head', [ __CLASS__, 'set_js_vars' ] );
+	}
 
 	/**
 	 * Enqueue all of the admin includes.
@@ -21,131 +22,165 @@ class ScormCloudAdminUi
 		wp_enqueue_style( 'scormcloud-admin-style' );
 	}
 
-    public static function admin_menu_actions()
-    {
-        self::enqueue_admin_includes();
+	/**
+	 * Generate the admin menu actions.
+	 */
+	public static function admin_menu_actions() {
+		self::enqueue_admin_includes();
 
-        $topslug = 'scormcloud/admin';
-        $plugin_hooks =& ScormCloudPlugin::$hooks;
-        $plugin_hooks[] = add_menu_page('SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, array(__CLASS__, 'show_start_page'));
-        $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Courses', 'Courses', 'publish_posts', 'scormcloud/manage_courses', array(__CLASS__, 'show_manage_courses'));
-        $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Training', 'Training', 'publish_posts', 'scormcloud/manage_training', array(__CLASS__, 'show_manage_training'));
-        $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/admin/settings', array(__CLASS__, 'show_settings'));
+		$topslug        = 'scormcloud/admin';
+		$plugin_hooks   =& ScormCloudPlugin::$hooks;
+		$plugin_hooks[] = add_menu_page( 'SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, [
+			__CLASS__,
+			'show_start_page',
+		] );
+		$plugin_hooks[] = add_submenu_page( $topslug, 'SCORM Cloud Courses', 'Courses', 'publish_posts', 'scormcloud/manage_courses', [
+			__CLASS__,
+			'show_manage_courses',
+		] );
+		$plugin_hooks[] = add_submenu_page( $topslug, 'SCORM Cloud Training', 'Training', 'publish_posts', 'scormcloud/manage_training', [
+			__CLASS__,
+			'show_manage_training',
+		] );
+		$plugin_hooks[] = add_submenu_page( $topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/admin/settings', [
+			__CLASS__,
+			'show_settings',
+		] );
 
-        add_action('contextual_help', array(__CLASS__, 'contextual_help'), 10, 3);
-    }
+		add_action( 'contextual_help', [ __CLASS__, 'contextual_help' ], 10, 3 );
+	}
 
-    public static function network_admin_menu_actions()
-    {
-        self::enqueue_admin_includes();
+	/**
+	 * Generate the admin menu actions for network admins.
+	 */
+	public static function network_admin_menu_actions() {
+		self::enqueue_admin_includes();
 
-        $topslug = 'scormcloud/network-admin';
-        $plugin_hooks =& ScormCloudPlugin::$hooks;
-        $plugin_hooks[] = add_menu_page('SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, array(__CLASS__, 'show_start_page'));
-        $plugin_hooks[] = add_submenu_page($topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/network-admin/settings', array(__CLASS__, 'show_network_settings'));
+		$topslug        = 'scormcloud/network-admin';
+		$plugin_hooks   =& ScormCloudPlugin::$hooks;
+		$plugin_hooks[] = add_menu_page( 'SCORM Cloud Overview', 'SCORM Cloud', 'publish_posts', $topslug, [
+			__CLASS__,
+			'show_start_page',
+		] );
+		$plugin_hooks[] = add_submenu_page( $topslug, 'SCORM Cloud Settings', 'Settings', 'publish_posts', 'scormcloud/network-admin/settings', [
+			__CLASS__,
+			'show_network_settings',
+		] );
 
-        add_action('contextual_help', array(__CLASS__, 'contextual_help'), 10, 3);
-    }
+		add_action( 'contextual_help', [ __CLASS__, 'contextual_help' ], 10, 3 );
+	}
 
-    public static function show_start_page()
-    {
-        include('startpage.php');
-    }
+	/**
+	 * Include the start page.
+	 */
+	public static function show_start_page() {
+		include( 'startpage.php' );
+	}
 
-    public static function show_manage_courses()
-    {
-        include('managecourses.php');
-    }
+	/**
+	 * Include the manage courses page.
+	 */
+	public static function show_manage_courses() {
+		include( 'managecourses.php' );
+	}
 
-    public static function show_manage_training()
-    {
-        include('managetraining.php');
-    }
+	/**
+	 * Include the manage training page.
+	 */
+	public static function show_manage_training() {
+		include( 'managetraining.php' );
+	}
 
-    public static function show_settings()
-    {
-        include('settings.php');
-    }
+	/**
+	 * Include the settings page.
+	 */
+	public static function show_settings() {
+		include( 'settings.php' );
+	}
 
-    public static function show_network_settings()
-    {
-        include('network_settings.php');
-    }
+	/**
+	 * Include the network settings page.
+	 */
+	public static function show_network_settings() {
+		include( 'network_settings.php' );
+	}
 
-    public static function set_js_vars()
-    {
-        ?>
-    <script type="text/javascript" charset="utf-8">
-    // <![CDATA[
-    	if (typeof ScormCloud !== 'undefined' && typeof ScormCloud.Dialog !== 'undefined') {
-            var dialogUrl = "<?php echo plugins_url('/scormcloud/ui/embedtrainingdialog.php'); ?>";
+	/**
+	 * Set the embed training url.
+	 */
+	public static function set_js_vars() {
+		?>
+		<script type="text/javascript" charset="utf-8">
+			// <![CDATA[
+			if (typeof ScormCloud !== 'undefined' && typeof ScormCloud.Dialog !== 'undefined') {
+                ScormCloud.Dialog.embedTrainingUrl = "<?php echo plugins_url( '/scormcloud/ui/embedtrainingdialog.php' ); ?>";
+			}
+			// ]]>
+		</script>
+		<?php
+	}
 
-    		ScormCloud.Dialog.embedTrainingUrl = dialogUrl;
-    	}
-    // ]]>
-    </script>
-        <?php
-    }
+	/**
+	 * Build contextual help stubs.
+	 */
+	public static function contextual_help( $text, $screen_id, $screen ) {
+		$plugin_hooks = ScormCloudPlugin::$hooks;
 
-    public static function contextual_help($text, $screen_id, $screen)
-    {
-        $plugin_hooks = ScormCloudPlugin::$hooks;
+		if ( substr( $screen_id, - 8 ) == '-network' ) {
+			$screen_id = substr_replace( $screen_id, '', - 8 );
+		}
 
-        if (substr($screen_id, -8) == '-network') {
-            $screen_id = substr_replace($screen_id, '', -8);
-        }
+		if ( in_array( $screen_id, $plugin_hooks ) ) {
 
-        if (in_array($screen_id, $plugin_hooks)){
+			$help_html = "<div class='sc_helpPanel'>";
+			$help_html .= "<h2>SCORM Cloud Hints and Tips</h2>";
 
-            $helpHtml = "<div class='sc_helpPanel'>";
-            $helpHtml .= "<h2>SCORM Cloud Hints and Tips</h2>";
+			if ( isset( $_GET[ 'page' ] ) ) {
+				$plugin_page = stripslashes( $_GET[ 'page' ] );
+				$plugin_page = plugin_basename( $plugin_page );
+			}
 
-            if ( isset($_GET['page']) ) {
-                $plugin_page = stripslashes($_GET['page']);
-                $plugin_page = plugin_basename($plugin_page);
-            }
+			switch ( $plugin_page ) {
 
-            switch ($plugin_page){
+				case 'scormcloud/network-admin':
+				case 'scormcloud/admin':
+					$help_html .= "<p><span class='emph'>Overall Reportage Summary</span> is a results report for all trainings in your wordpress plugin."
+    	            $help_html .= "Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'Scorm Cloud Reportage' link under the page header.";
+					$help_html .= '</p>';
+					break;
 
-                case 'scormcloud/network-admin':
-                case 'scormcloud/admin':
-                    $helpHtml .= "<p><span class='emph'>Overall Reportage Summary</span> is a results report for all trainings in your wordpress plugin.
-    	            Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'Scorm Cloud Reportage' link under the page header.";
-                    $helpHtml .= "</p>";
-                    break;
-
-                case 'scormcloud/manage_courses':
-                    $helpHtml .= "<p><span class='emph'>Import a new course</span> provides functionality to upload a course to the SCORM Cloud for use in trainings in wordpress.
+				case 'scormcloud/manage_courses':
+					$help_html .= "<p><span class='emph'>Import a new course</span> provides functionality to upload a course to the SCORM Cloud for use in trainings in wordpress.
     	            Files uploaded should be zipped up SCORM or AICC course packages.</p>";
-                    $helpHtml .= "<p><span class='emph'>All Courses</span> lists all of the courses available for training in wordpress.  This list comes from the SCORM Cloud, and the courses can also be managed on the SCORM Cloud site.
+					$help_html .= "<p><span class='emph'>All Courses</span> lists all of the courses available for training in wordpress.  This list comes from the SCORM Cloud, and the courses can also be managed on the SCORM Cloud site.
     	            <ul>
     	            <li>Click the <span class='emph'>Preview</span> link to launch an untracked preview of the course.  This will launch the full course, but no results will be recorded.</li>
     	            <li>Clicking the <span class='emph'>View Course Report</span> link will open the full reportage report for the course in the Reportage Application.</li>
     	            <li>Clicking the <span class='emph'>Delete Course</span> link will delete the course from wordpress and from the SCORM Cloud.  Any trainings associated with the course, however,
     	            will not be deleted.</li>
     	            </ul></p>";
-                    break;
+					break;
 
-                case 'scormcloud/manage_training':
+				case 'scormcloud/manage_training':
 
-                    if (isset($_GET['inviteid'])){
-                        $helpHtml .= "<p>Clicking the <span class='emph'>click to activate/deactivate</span> link will set the training as launchable or not launchable.</p>";
-                        $helpHtml .= "<p><span class='emph'>Invitation Details</span> provides a way to modify an existing post/page invitation.  An example of what the invitation will
+					if ( isset( $_GET[ 'inviteid' ] ) ) {
+						$help_html .= "<p>Clicking the <span class='emph'>click to activate/deactivate</span> link will set the training as launchable or not launchable.</p>";
+						$help_html .= "<p><span class='emph'>Invitation Details</span> provides a way to modify an existing post/page invitation.  An example of what the invitation will
     	                look like in the post is displayed to the right of the edit fields.  This section will not appear for 'Catalog Widget' and 'Quick Create Training' trainings.</p>";
-                        $helpHtml .= "<p><span class='emph'>Training Summary</span> is a results report for all learners who have started this training.
+						$help_html .= "<p><span class='emph'>Training Summary</span> is a results report for all learners who have started this training.
     	                Note that the results are not reported in real time but are current as of the given date.  You can view the full report in the Reportage site by clicking the 'View Full Results Report' link.";
-                        $helpHtml .= "<p><span class='emph>Training History</span> lists all of the learners that have started or have been assigned this training.
+						$help_html .= "<p><span class='emph>Training History</span> lists all of the learners that have started or have been assigned this training.
     	                You can view the full learners report in the Reportage site by clicking the 'View All Learners in Reportage' link.
     	                <ul>
     	                <li>Click the <span class='emph'>View Details</span> link see a detailed report of a learner's results in Reportage.</li>
     	                </ul>
     	                </p>";
-                    } else {
+					} else {
 
-                        $helpHtml .= "<p><span class='emph'>Quick Create Training</span> provides the ability to directly assign a course to existing wordpress users.  These trainings will not appear
+						$help_html .= "<p><span class='emph'>Quick Create Training</span> provides the ability to directly assign a course to existing wordpress users.  These trainings will not appear
     	                in a wordpress post or page, but the course will show up in the user's <span class='emph'>SCORM Cloud User Training Widget</span>; so it is important to add that widget to your wordpress blog for the users
     	                to be able to launch the assigned courses.  Note that using this functionality to assign courses pre-creates a registration in your SCORM Cloud account for each assigned course and user.</p>";
-                        $helpHtml .= "<p><span class='emph'>SCORM Cloud Training History</span> lists all of the trainings that have been created in your wordpress site.
+						$help_html .= "<p><span class='emph'>SCORM Cloud Training History</span> lists all of the trainings that have been created in your wordpress site.
     	                <ul>
     	                <li>Click the <span class='emph'>Course Title</span> link to go to a training detail page.</li>
     	                <li>The <span class='emph'>Post Title</span> shows which page or blog post contains the training launch. Clicking the title will open the edit page for that post.  A non-link 'Catalog Widget' title indicates the training was created and launched
@@ -156,40 +191,40 @@ class ScormCloudAdminUi
     	                <li>Clicking the <span class='emph'>click to activate/deactivate</span> link will set the training as launchable or not launchable.</li>
     	                </ul>
     	                </p>";
-                    }
-                    break;
+					}
+					break;
 
-                case 'scormcloud/admin/settings':
-                    $helpHtml .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
-                    $helpHtml .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
-                    $helpHtml .= '<p>The <span class="emph">SCORM Player Stylesheet URL</span> controls the CSS stylesheet used to style the user interface of the SCORM player.</p>';
-                    break;
+				case 'scormcloud/admin/settings':
+					$help_html .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
+					$help_html .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
+					$help_html .= '<p>The <span class="emph">SCORM Player Stylesheet URL</span> controls the CSS stylesheet used to style the user interface of the SCORM player.</p>';
+					break;
 
-                case 'scormcloud/network-admin/settings':
-                    $helpHtml .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
-                    $helpHtml .= '<p><span class="emph">Use same SCORM Cloud account across all sites:</span> If enabled, all sites in the network will use the SCORM Cloud account credentials and Engine URL and administrators for those sites will not be able to change these settings.</p>';
-                    $helpHtml .= '<p><span class="emph">Share courses among all sites:</span> If enabled, all sites will use and upload to the same course library on the SCORM Cloud for creating training.</p>';
-                    $helpHtml .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
-                    break;
+				case 'scormcloud/network-admin/settings':
+					$help_html .= '<p>The <span class="emph">App Id</span> and <span class="emph">Secret Key</span> can both be found by going to your <a href="http://cloud.scorm.com/sc/user/Apps">Apps Page</a> on the SCORM Cloud site. These values are essentially the "username and password" for WordPress to access your SCORM Cloud account.</p>';
+					$help_html .= '<p><span class="emph">Use same SCORM Cloud account across all sites:</span> If enabled, all sites in the network will use the SCORM Cloud account credentials and Engine URL and administrators for those sites will not be able to change these settings.</p>';
+					$help_html .= '<p><span class="emph">Share courses among all sites:</span> If enabled, all sites will use and upload to the same course library on the SCORM Cloud for creating training.</p>';
+					$help_html .= '<p>The <span class="emph">Cloud Engine URL</span> is set with a default value that does not need to be changed for most users.</p>';
+					break;
 
-                default:
-                    $helpHtml .= "<p><span class='emph'></span></p>";
-                    break;
-
-
-            }
-
-            $helpHtml .= "<hr>";
-
-            $helpHtml .= "<p>The SCORM Cloud plugin requires a SCORM Cloud account that can be created and managed on the <a href='https://cloud.scorm.com/'>SCORM Cloud</a> application site.</p>";
-            $helpHtml .= "<p>The SCORM Cloud is brought to you by <a href='https://www.scorm.com/'>Rustici Software</a>.</p>";
+				default:
+					$help_html .= "<p><span class='emph'></span></p>";
+					break;
 
 
+			}
 
-            $helpHtml .= "</div>";
-            return $helpHtml;
-        } else {
-            return $text;
-        }
-    }
+			$help_html .= "<hr>";
+
+			$help_html .= "<p>The SCORM Cloud plugin requires a SCORM Cloud account that can be created and managed on the <a href='https://cloud.scorm.com/'>SCORM Cloud</a> application site.</p>";
+			$help_html .= "<p>The SCORM Cloud is brought to you by <a href='https://www.scorm.com/'>Rustici Software</a>.</p>";
+
+
+			$help_html .= "</div>";
+
+			return $help_html;
+		} else {
+			return $text;
+		}
+	}
 }

--- a/scormcloud/admin/settings.php
+++ b/scormcloud/admin/settings.php
@@ -95,7 +95,7 @@ if(isset($_POST['scormcloud_hidden']) && $_POST['scormcloud_hidden'] == 'Y') {
 <?php } ?>
 <?php if (is_super_admin()) {?>
 <p>
-<a href="<?php echo(get_option('siteurl').'/wp-admin/network/admin.php?page=scormcloud/network-admin/settings'); ?>"><?php _e('Network Admin Settings'); ?></a>
+<a href="<?php echo(site_url().'/wp-admin/network/admin.php?page=scormcloud/network-admin/settings'); ?>"><?php _e('Network Admin Settings'); ?></a>
 </p>
 <?php } ?>
 <h3><?php _e('Advanced Settings'); ?></h3>

--- a/scormcloud/admin/startpage.php
+++ b/scormcloud/admin/startpage.php
@@ -22,9 +22,9 @@ try {
 if ($isValidAccount){
     //Reportage Includes
     echo '<script type="text/javascript" ';
-    echo "src=\"http://cloud.scorm.com/Reportage/scripts/reportage.combined.js\"></script>\n";
+    echo "src=\"https://cloud.scorm.com/Reportage/scripts/reportage.combined.js\"></script>\n";
     echo '<link rel="stylesheet" ';
-    echo "href=\"http://cloud.scorm.com/Reportage/css/reportage.combined.css\" type=\"text/css\" media=\"screen\" />\n";
+    echo "href=\"https://cloud.scorm.com/Reportage/css/reportage.combined.css\" type=\"text/css\" media=\"screen\" />\n";
     echo '<div class="mod-scormcloud">';
 
     //Check for some defaults to set the form up
@@ -52,11 +52,11 @@ if (!$isValidAccount){
 
     if (is_super_admin())
     {
-        $settings_url = get_option('siteurl').'/wp-admin/network/admin.php?page=scormcloud/network-admin/settings';
+        $settings_url = site_url().'/wp-admin/network/admin.php?page=scormcloud/network-admin/settings';
     }
     else
     {
-        $settings_url = get_option('siteurl').'/wp-admin/admin.php?page=scormcloud/admin/settings';
+        $settings_url = site_url().'/wp-admin/admin.php?page=scormcloud/admin/settings';
     }
     echo '<div class="settingsPageLink"><a href="'.$settings_url.'"
 				title="'. __("Click here to configure your SCORM Cloud plugin.","scormcloud").'">'. __("Click Here to go to the settings page to configure the SCORM Cloud wordpress Plugin.","scormcloud").'</a></div>';

--- a/scormcloud/admin/trainingdetails.php
+++ b/scormcloud/admin/trainingdetails.php
@@ -15,7 +15,7 @@ $invite = $wpdb->get_row($query, OBJECT);
 
 ?>
 <div class="scormcloud-admin-page trainingDetail"><a class='backLink'
-	href='<?php echo get_option( 'siteurl' )."/wp-admin/admin.php?page=scormcloud/manage_training"; ?>'><?php _e("Go back to all trainings","scormcloud"); ?></a>
+	href='<?php echo site_url()."/wp-admin/admin.php?page=scormcloud/manage_training"; ?>'><?php _e("Go back to all trainings","scormcloud"); ?></a>
 
 <h2><?php echo __("Training Details for","scormcloud").' "'.$invite->course_title; ?>"</h2>
 <div class="invitationStatus"><?php
@@ -31,7 +31,7 @@ if ($invite->active != 2){
 <?php if ($invite->post_id != "__direct_invite__" && $invite->post_id != "__catalog_widget__"){ ?>
 <div class='meta-box-sortables'>
 <div
-	class='reportageWrapper postbox <?php echo ($isValidAccount ? "closed" : ""); ?>'>
+	class='reportageWrapper postbox <?php echo ($is_valid_account ? "closed" : ""); ?>'>
 <div title='<?php _e("Click to toggle","scormcloud"); ?>'
 	class='handlediv'><br>
 </div>
@@ -134,7 +134,7 @@ if ($invite->active != 2){
             
             $j.ajax({
 			type: "POST",
-			url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+			url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
 			data: 	"action=updatePostInvite" +
                     "&inviteid=<?php echo $inviteId; ?>" +
 					"&header=" + header +
@@ -156,7 +156,7 @@ if ($invite->active != 2){
         
 		
 </script> <?php }
-if ($isValidAccount){
+if ($is_valid_account){
     ?>
 
 <div class='meta-box-sortables'>
@@ -276,7 +276,7 @@ jQuery(".viewReportageLink").click(function(){
      
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=getInviteReportUrl" +
                 "&inviteid=" + invId,
         success: function(url){
@@ -298,7 +298,7 @@ jQuery('.activateLink').click(function(){
     
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=setactive" +
                 "&inviteid=" + invId +
                 "&active=" + (wasActive ? '0' : '1'),
@@ -324,7 +324,7 @@ function Scormcloud_loadRegReport(invId,regId){
                     
     jQuery.ajax({
         type: "POST",
-        url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
+        url: "<?php echo site_url() . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
         data: 	"action=getRegReportUrl" +
                 "&inviteid=" + invId +
                 "&regid=" + regId,
@@ -344,7 +344,7 @@ function Scormcloud_loadRegReport(invId,regId){
     echo "<div>
             <h2>" . __("Please configure your SCORM Cloud settings to see training results.","scormcloud") . "</h2>
         </div>";
-    echo '<div class="settingsPageLink"><a href="'.get_option( 'siteurl' ).'/wp-admin/admin.php?page=scormcloudsettings"
+    echo '<div class="settingsPageLink"><a href="'.site_url().'/wp-admin/admin.php?page=scormcloudsettings"
 				title="'.__("Click here to configure your SCORM Cloud plugin.","scormcloud").'">' . __("Click Here to go to the settings page.","scormcloud") . '</a></div>';
 
 }

--- a/scormcloud/ajax.php
+++ b/scormcloud/ajax.php
@@ -448,7 +448,7 @@ switch ( $action ) {
 	case 'getPropertiesEditorUrl':
 		$course_id     = get_post_arg_as_string( 'courseid' );
 		$course_service = $cloud_service->getCourseService();
-		$cssurl        = get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/css/scormcloud.ppeditor.css';
+		$cssurl        = site_url() . '/wp-content/plugins/scormcloud/css/scormcloud.ppeditor.css';
 
 		echo esc_url_raw( $course_service->GetPropertyEditorUrl( $course_id, $cssurl, null ) );
 
@@ -585,7 +585,7 @@ switch ( $action ) {
 		echo '</table>';
 
 		if ( count( $invite_regs ) >= 10 ) {
-			echo '<div class="viewInviteLink"><a href="' . esc_url_raw( get_option( 'siteurl' ) . '/wp-admin/admin.php?page=scormcloudtraining&inviteid=' . $invite_id ) . '">Click here to see complete training history.</a></div>';
+			echo '<div class="viewInviteLink"><a href="' . esc_url_raw( site_url() . '/wp-admin/admin.php?page=scormcloudtraining&inviteid=' . $invite_id ) . '">Click here to see complete training history.</a></div>';
 		}
 		break;
 

--- a/scormcloud/importcallback.php
+++ b/scormcloud/importcallback.php
@@ -14,56 +14,54 @@
  ==============================================================================
  */
 global $wpdb;
-if ( defined('ABSPATH') )
-require_once(ABSPATH . 'wp-load.php');
-else
-require_once('../../../wp-load.php');
-require_once(ABSPATH . 'wp-admin/includes/admin.php');
+if ( defined( 'ABSPATH' ) ) {
+	require_once( ABSPATH . 'wp-load.php' );
+} else {
+	require_once( '../../../wp-load.php' );
+}
+require_once( ABSPATH . 'wp-admin/includes/admin.php' );
 
-require_once(SCORMCLOUD_BASE.'scormcloudplugin.php');
+require_once( SCORMCLOUD_BASE . 'scormcloudplugin.php' );
 $ScormService = ScormCloudPlugin::get_cloud_service();
 
-$scormcloudid = $_GET['courseid'];
-$mode = $_GET['mode'];
-if($mode == null)
-{
-    $mode = 'new';
+$scormcloudid = $_GET[ 'courseid' ];
+$mode         = $_GET[ 'mode' ];
+if ( $mode == null ) {
+	$mode = 'new';
 }
 
-$location = $_GET['location'];
-$success = $_GET['success'];
+$location = $_GET[ 'location' ];
+$success  = $_GET[ 'success' ];
 
-wp_enqueue_style("global");
-wp_enqueue_style("wp-admin");
-wp_register_style('scormcloud-admin-style', plugins_url('/scormcloud/css/scormcloud.admin.css'));
-wp_enqueue_style('scormcloud-admin-style');
+wp_enqueue_style( "global" );
+wp_enqueue_style( "wp-admin" );
+wp_register_style( 'scormcloud-admin-style', plugins_url( '/css/scormcloud.admin.css' ) );
+wp_enqueue_style( 'scormcloud-admin-style' );
 wp_print_styles();
 
 $courseService = $ScormService->getCourseService();
 
 
-if($success=='true')
-{
-    echo '<span class="importMessage">'.__("Processing Import....","scormcloud").'</span>';
+if ( $success == 'true' ) {
+	echo '<span class="importMessage">' . __( "Processing Import....", "scormcloud" ) . '</span>';
 
-    if($mode == 'update')
-    {
-        //version the uploaded course
-        $result = $courseService->VersionUploadedCourse($scormcloudid, $location, null);
-        $importResult = new ImportResult($result);
+	if ( $mode == 'update' ) {
+		//version the uploaded course
+		$result = $courseService->VersionUploadedCourse( $scormcloudid, $location, null );
+		$importResult = new ImportResult( $result );
 
-    }else{
+	} else {
 
-        //import the uploaded course
-        $result = $courseService->ImportUploadedCourse($scormcloudid, $location, null);
+		//import the uploaded course
+		$result = $courseService->ImportUploadedCourse( $scormcloudid, $location, null );
 
 
-    }
+	}
 
-    echo '<script>window.parent.location=window.parent.location;</script>';
+	echo '<script>window.parent.location=window.parent.location;</script>';
 
-}else{
-    echo '<span class="importMessage">'.__("There was an error uploading your package. Please try again.","scormcloud").'</span>';
+} else {
+	echo '<span class="importMessage">' . __( "There was an error uploading your package. Please try again.", "scormcloud" ) . '</span>';
 
 
 }

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -3,7 +3,7 @@ Contributors: troyef, stuartchilds, timedwards
 Tags: elearning, learning, scorm, aicc, education, training, cloud
 Requires at least: 4.3
 Tested up to: 5.6
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 
 Tap the power of SCORM to deliver and track training right from your WordPress-powered site.
 
@@ -48,6 +48,10 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 1.2.1 =
+* Removed more deprecated methods
+* Honor http/https schema being used for css/javascript includes
+
 = 1.2.0 =
 * Removed deprecated WP methods
 

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: troyef, stuartchilds
+Contributors: troyef, stuartchilds, timedwards
 Tags: elearning, learning, scorm, aicc, education, training, cloud
 Requires at least: 4.3
 Tested up to: 5.6
@@ -48,6 +48,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 1.2.0 =
+* Removed deprecated WP methods
+
 = 1.1.9 =
 * Updates Training View
 * Updates to synching learner information

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -25,3 +25,5 @@ add_action( 'init', array( 'ScormCloudPlugin', 'initialize' ) );
 add_action( 'init', array( 'ScormCloudUi', 'initialize' ) );
 add_action( 'widgets_init', array( 'ScormCloudUi', 'initialize_widgets' ) );
 
+add_filter( 'script_loader_src', array( 'ScormCloudPlugin', 'agnostic_loader' ), 20, 2 );
+add_filter( 'style_loader_src', array( 'ScormCloudPlugin', 'agnostic_loader' ), 20, 2 );

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@
  Plugin URI: http://scorm.com/wordpress
  Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
  Author: Rustici Software
- Version: 1.2.0
+ Version: 1.2.1
  Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -87,7 +87,7 @@ class ScormCloudContentHandler {
 							if ( 0 === (int) $invite->require_login ) {
 								$invite_html .= "<p class='inputs'>My name is <input name='scormcloudfname' placeholder='First Name' type='text' key='$invite_id'/>&nbsp;<input name='scormcloudlname' placeholder='Last Name' type='text' key='$invite_id'/>";
 								$invite_html .= " and my email is <input name='scormcloudemail' placeholder='Email' type='text' key='$invite_id'/> .</p>";
-								$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.makeAnonRegLaunch(\"$invite_id\");' url='" . get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php' value='Start Training'/>";
+								$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.makeAnonRegLaunch(\"$invite_id\");' url='" . site_url() . "/wp-content/plugins/scormcloud/ajax.php' value='Start Training'/>";
 							} else {
 								$invite_html .= '<h3>' . __( 'Please log in to take this training.', 'scormcloud' ) . '</h3>';
 							}
@@ -124,12 +124,12 @@ class ScormCloudContentHandler {
 							               '</tr></table>';
 
 
-							$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.getLaunchURL(\"$invite_id\",\"$reg_id\");' url='" . get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php' value='" . __( 'Relaunch Training', 'scormcloud' ) . "' />";
+							$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.getLaunchURL(\"$invite_id\",\"$reg_id\");' url='" . site_url() . "/wp-content/plugins/scormcloud/ajax.php' value='" . __( 'Relaunch Training', 'scormcloud' ) . "' />";
 
 
 						} else {
 							if ( $remaining_registrations > 0 ) {
-								$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.makeUserRegLaunch(\"$invite_id\");' url='" . get_option( 'siteurl' ) . "/wp-content/plugins/scormcloud/ajax.php' value='Start Training'/>";
+								$invite_html .= "<input name='launch' type='button' key='$invite_id' onclick='ScormCloud.Post.makeUserRegLaunch(\"$invite_id\");' url='" . site_url() . "/wp-content/plugins/scormcloud/ajax.php' value='Start Training'/>";
 							} else {
 								$invite_html .= '<h3>' . __( 'This training is not currently active.', 'scormcloud' ) . '</h3>';
 							}

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -136,5 +136,17 @@ class ScormCloudPlugin {
 			return $reg_limit - $reg_usage;
 		}
 	}
+
+	/**
+	 * Removes http: and https: from a url.
+	 *
+	 * @param string $src The url to strip.
+	 * @param string $handle The handle of the script/css being enqueued.
+	 *
+	 * @return String
+	 */
+	public static function agnostic_loader( $src, $handle ) {
+		return preg_replace( '/^(http|https):/', '', $src );
+	}
 }
 

--- a/scormcloud/scormcloudui.php
+++ b/scormcloud/scormcloudui.php
@@ -35,9 +35,9 @@ class ScormCloudUi {
 		wp_enqueue_script( 'thickbox' );
 		wp_enqueue_style( 'thickbox' );
 
-		wp_enqueue_script( 'scormclouddialog', plugins_url( '/scormcloud/scripts/scormcloud.dialog.js', __FILE__ ) );
-		wp_enqueue_script( 'scormcloud-post', plugins_url( '/scormcloud/scripts/scormcloud.post.js', __FILE__ ) );
-		wp_register_style( 'scormcloud-post-style', plugins_url( '/scormcloud/css/scormcloud.post.css', __FILE__ ) );
+		wp_enqueue_script( 'scormclouddialog', plugins_url( '/scripts/scormcloud.dialog.js', __FILE__ ) );
+		wp_enqueue_script( 'scormcloud-post', plugins_url( '/scripts/scormcloud.post.js', __FILE__ ) );
+		wp_register_style( 'scormcloud-post-style', plugins_url( '/css/scormcloud.post.css', __FILE__ ) );
 		wp_enqueue_style( 'scormcloud-post-style' );
 	}
 
@@ -60,7 +60,7 @@ class ScormCloudUi {
 	 * @return mixed
 	 */
 	public static function embed_editor_plugin( $plugins ) {
-		$plugins['scormCloudEmbed'] = plugins_url( '/scormcloud/tinymce3/editor_plugin.js' );
+		$plugins['scormCloudEmbed'] = plugins_url( '/tinymce3/editor_plugin.js', __FILE__ );
 
 		return $plugins;
 	}

--- a/scormcloud/scormcloudui.php
+++ b/scormcloud/scormcloudui.php
@@ -35,9 +35,9 @@ class ScormCloudUi {
 		wp_enqueue_script( 'thickbox' );
 		wp_enqueue_style( 'thickbox' );
 
-		wp_enqueue_script( 'scormclouddialog', plugins_url( '/scormcloud/scripts/scormcloud.dialog.js' ), array() );
-		wp_enqueue_script( 'scormcloud-post', plugins_url( '/scormcloud/scripts/scormcloud.post.js' ), array() );
-		wp_register_style( 'scormcloud-post-style', plugins_url( '/scormcloud/css/scormcloud.post.css' ) );
+		wp_enqueue_script( 'scormclouddialog', plugins_url( '/scormcloud/scripts/scormcloud.dialog.js', __FILE__ ) );
+		wp_enqueue_script( 'scormcloud-post', plugins_url( '/scormcloud/scripts/scormcloud.post.js', __FILE__ ) );
+		wp_register_style( 'scormcloud-post-style', plugins_url( '/scormcloud/css/scormcloud.post.css', __FILE__ ) );
 		wp_enqueue_style( 'scormcloud-post-style' );
 	}
 

--- a/scormcloud/ui/embedtrainingdialog.php
+++ b/scormcloud/ui/embedtrainingdialog.php
@@ -1,186 +1,190 @@
 <?php
 
 /* Finding the path to the wp-admin folder */
-$iswin = preg_match('/:\\\/', dirname(__file__));
-$slash = ($iswin) ? "\\" : "/";
+$iswin = preg_match( '/:\\\/', dirname( __file__ ) );
+$slash = ( $iswin ) ? "\\" : "/";
 
-$wp_path = preg_split('/(?=((\\\|\/)wp-content)).*/', dirname(__file__));
-$wp_path = (isset($wp_path[0]) && $wp_path[0] != "") ? $wp_path[0] : $_SERVER["DOCUMENT_ROOT"];
+$wp_path = preg_split( '/(?=((\\\|\/)wp-content)).*/', dirname( __file__ ) );
+$wp_path = ( isset( $wp_path[ 0 ] ) && $wp_path[ 0 ] !== "" ) ? $wp_path[ 0 ] : $_SERVER[ "DOCUMENT_ROOT" ];
 
 /** Load WordPress Administration Bootstrap */
-require_once($wp_path . $slash . 'wp-load.php');
-require_once($wp_path . $slash . 'wp-admin' . $slash . 'admin.php');
+require_once( $wp_path . $slash . 'wp-load.php' );
+require_once( $wp_path . $slash . 'wp-admin' . $slash . 'admin.php' );
 
 global $wpdb;
 
 
-require_once(SCORMCLOUD_BASE.'scormcloudplugin.php');
+require_once( SCORMCLOUD_BASE . 'scormcloudplugin.php' );
 
-$ScormService = ScormCloudPlugin::get_cloud_service();
+$scorm_service = ScormCloudPlugin::get_cloud_service();
 try {
-    $isValidAccount = $ScormService->isValidAccount();
-} catch (Exception $e) {
-    $isValidAccount = false;
+	$is_valid_account = $scorm_service->isValidAccount();
+} catch ( Exception $e ) {
+	$is_valid_account = false;
 }
 
-if ($isValidAccount){
-    ?>
-<div id="embedTrainingDialog">
-<h1><?php _e("Add training to your post","scormcloud"); ?></h1>
+if ( $is_valid_account ) {
+	?>
+	<div id="embedTrainingDialog">
+		<h1><?php esc_attr_e( 'Add training to your post', 'scormcloud' ); ?></h1>
 
 
-<span class="labelheader"><?php _e("First select a course","scormcloud"); ?>:
-</span> 
-<select class="courseSelector">
-
-<?php
-
-echo "<option value=''></option>";
-$coursesFilter = (ScormCloudPlugin::is_network_managed() && get_site_option('scormcloud_sharecourses') !== '1') ? $GLOBALS['blog_id']."-.*" : null ;
-$courseService = $ScormService->getCourseService();
-$allResults = $courseService->GetCourseList($coursesFilter);
-foreach($allResults as $course){
-    echo "<option value='".$course->getCourseId()."'>".$course->getTitle()."</option>";
-}
-
-?>
-</select> <br />
-<br />
-
-<div class='selectOptionsDiv'><span class="labelheader"><?php _e("Next select some options","scormcloud"); ?>:
+		<span class="labelheader"><?php esc_attr_e( 'First select a course', 'scormcloud' ); ?>:
 </span>
-<table>
-	<tr>
-		<td class="label"><?php _e("Training Header Text","scormcloud"); ?>:</td>
-		<td><input type="text" name="trainingHeaderTxt"
-			value="<?php _e("Launch Training Now","scormcloud"); ?>" /></td>
-	</tr>
-	<tr>
-		<td class="label"><?php _e("Training Description","scormcloud"); ?>:</td>
-		<td><textarea type="text" name="trainingDesc"><?php _e("Click 'Start Training' to take your training.","scormcloud"); ?></textarea></td>
-	</tr>
-	<tr>
-		<td colspan='2'><input type="checkbox" checked
-			name="trainingRequireLogin" /><?php _e("Require that learners be authenticated users.","scormcloud"); ?></td>
-	</tr>
-	<tr>
-		<td colspan='2'><input type="checkbox" checked name="showCourseInfo" /><?php _e("Show the course title and description.","scormcloud"); ?></td>
-	</tr>
+		<select class="courseSelector">
 
-</table>
+			<?php
 
-
-
-<input type="button" class="generateTrainingTag button"
-	name="generateTrainingTag"
-	value="<?php _e("Embed This Training","scormcloud"); ?>" /> <a
-	href="javascript:void(0);" class="toggleButton previewPostEmbed"
-	toggleobject='#embedTrainingDialog .previewDiv'
-	onText='<?php _e("hide preview","scormcloud"); ?>'
-	offText='<?php _e("show preview","scormcloud"); ?>'><?php _e("show preview","scormcloud"); ?></a>
-<div class="previewDiv">
-<div class="scormCloudInvitation">
-<h3><?php _e("Launch Training Now","scormcloud"); ?></h3>
-<p class="description"><?php _e("Click 'Start Training' to take your training.","scormcloud"); ?></p>
-<div class="courseInfo">
-<div class="title"></div>
-<div class="desc"><?php _e("This will be the metadata description for your course (if it exists).  Also, the displayed duration will render if it exists in the metadata.","scormcloud"); ?></div>
-<div class="duration"><?php _e("Duration: 10 minutes","scormcloud"); ?></div>
-</div>
-<p class="inputs"><?php _e("My name is","scormcloud"); ?> <input
-	disabled name="scormcloudfname" placeholder="First Name" type="text"> <input
-	name="scormcloudlname" disabled placeholder="Last Name" type="text"> <?php _e("and my email is","scormcloud"); ?>
-<input name="scormcloudemail" disabled placeholder="Email" type="text">
-.</p>
-<input type="button" class="button"
-	value="<?php _e("Start Training","scormcloud"); ?>"
-	onclick="return false;" name="launch"></div>
-</div>
-
-</div>
-<script type="text/javascript" charset="utf-8">
-	var $j = jQuery.noConflict();
-    $j(document).ready(function(){
-        
-        $j('#TB_ajaxContent').removeAttr('style');
-        $j('#TB_window').css('overflow-y','auto');
-        
-        $j('#embedTrainingDialog .toggleButton').toggle(function(){
-            $j($j(this).attr('toggleobject')).fadeIn('slow');
-            $j(this).text($j(this).attr('onText'));
-        },function(){
-            $j($j(this).attr('toggleobject')).fadeOut('slow');
-            $j(this).text($j(this).attr('offText'));
-        });
-        
-        $j('#embedTrainingDialog .courseSelector').change(function(){
-            var selObj = $j('#embedTrainingDialog .courseSelector option:selected');
-            if (selObj.val() != ''){
-                //var newheader = 'Training: ' + selObj.text();
-                //$j('#embedTrainingDialog input[name="trainingHeaderTxt"]').val(newheader);
-                //$j('#embedTrainingDialog .previewDiv h3').text(newheader);
-                $j('#embedTrainingDialog .previewDiv div.courseInfo div.title').text('<?php _e("Title","scormcloud"); ?>: ' + selObj.text());
-                $j('#embedTrainingDialog .selectOptionsDiv').fadeIn('slow');
-                tb_position();
-            }
-        });
-        
-        $j('#embedTrainingDialog input[name="trainingHeaderTxt"]').change(function(){
-            $j('#embedTrainingDialog .previewDiv h3').text($j(this).val());
-        });
-        $j('#embedTrainingDialog textarea[name="trainingDesc"]').change(function(){
-            $j('#embedTrainingDialog p.description').text($j(this).val());
-        });
-        $j('#embedTrainingDialog input[name="trainingRequireLogin"]').change(function(){
-            $j('#embedTrainingDialog .previewDiv p.inputs').toggle();
-        });
-        $j('#embedTrainingDialog input[name="showCourseInfo"]').change(function(){
-            $j('#embedTrainingDialog .previewDiv div.courseInfo').toggle();
-        });
-        
-        $j("#embedTrainingDialog .generateTrainingTag").click(function(e) {
-            
-            
-            var courseId = $j('#embedTrainingDialog .courseSelector option:selected').attr('value');
-            var courseTitle = $j('#embedTrainingDialog .courseSelector option:selected').text();
-            var header = $j('#embedTrainingDialog input[name="trainingHeaderTxt"]').attr('value');
-            var description = $j('#embedTrainingDialog textarea[name="trainingDesc"]').attr('value');
-            var requirelogin = $j('#embedTrainingDialog input[name="trainingRequireLogin"]:checked').length;
-            var showcourseinfo = $j('#embedTrainingDialog input[name="showCourseInfo"]:checked').length;
-            
-            $j.ajax({
-			type: "POST",
-			url: "<?php echo get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/ajax.php'; ?>",
-			data: 	"action=addPostInvite" + 
-					"&courseid=" + courseId +
-                    "&coursetitle=" + courseTitle +
-                    "&header=" + header +
-                    "&description=" + description +
-                    "&requirelogin=" + requirelogin +
-                    "&showcourseinfo=" + showcourseinfo,
-			success: function(html){
-			    ScormCloud.Dialog.insertTag("[scormcloud.training:"+ html + "]");
+			echo "<option value=''></option>";
+			$courses_filter = ( ScormCloudPlugin::is_network_managed() && get_site_option( 'scormcloud_sharecourses' ) !== '1' ) ? $GLOBALS['blog_id'] . '-.*' : null;
+			$course_service  = $scorm_service->getCourseService();
+			$all_results     = $course_service->GetCourseList( $courses_filter );
+			foreach ( $all_results as $course ) {
+				echo "<option value='" . esc_attr( $course->getCourseId() ) . "'>" . esc_attr( $course->getTitle() ) . '</option>';
 			}
-            });
-            
-            
-        });
-       
-       
-    });
 
-    
-        
-		
-</script></div>
-<?php
+			?>
+		</select> <br/>
+		<br/>
+
+		<div class='selectOptionsDiv'><span class="labelheader"><?php esc_attr_e( 'Next select some options', 'scormcloud' ); ?>
+				:
+</span>
+			<table>
+				<tr>
+					<td class="label"><?php esc_attr_e( 'Training Header Text', 'scormcloud' ); ?>:</td>
+					<td><input type="text" name="trainingHeaderTxt"
+							   value="<?php esc_attr_e( 'Launch Training Now', 'scormcloud' ); ?>"/></td>
+				</tr>
+				<tr>
+					<td class="label"><?php esc_attr_e( 'Training Description', 'scormcloud' ); ?>:</td>
+					<td><textarea type="text"
+								  name="trainingDesc"><?php esc_attr_e( "Click 'Start Training' to take your training.", 'scormcloud' ); ?></textarea>
+					</td>
+				</tr>
+				<tr>
+					<td colspan='2'><input type="checkbox" checked
+										   name="trainingRequireLogin"/><?php esc_attr_e( 'Require that learners be authenticated users.', 'scormcloud' ); ?>
+					</td>
+				</tr>
+				<tr>
+					<td colspan='2'><input type="checkbox" checked
+										   name="showCourseInfo"/><?php esc_attr_e( 'Show the course title and description.', 'scormcloud' ); ?>
+					</td>
+				</tr>
+
+			</table>
+
+
+			<input type="button" class="generateTrainingTag button"
+				   name="generateTrainingTag"
+				   value="<?php esc_attr_e( 'Embed This Training', 'scormcloud' ); ?>"/> <a
+					href="javascript:void(0);" class="toggleButton previewPostEmbed"
+					toggleobject='#embedTrainingDialog .previewDiv'
+					onText='<?php esc_attr_e( 'hide preview', 'scormcloud' ); ?>'
+					offText='<?php esc_attr_e( 'show preview', 'scormcloud' ); ?>'><?php esc_attr_e( 'show preview', 'scormcloud' ); ?></a>
+			<div class="previewDiv">
+				<div class="scormCloudInvitation">
+					<h3><?php esc_attr_e( 'Launch Training Now', 'scormcloud' ); ?></h3>
+					<p class="description"><?php esc_attr_e( "Click 'Start Training' to take your training.", 'scormcloud' ); ?></p>
+					<div class="courseInfo">
+						<div class="title"></div>
+						<div class='desc'><?php esc_attr_e( 'This will be the metadata description for your course (if it exists).  Also, the displayed duration will render if it exists in the metadata.', 'scormcloud' ); ?></div>
+						<div class='duration'><?php esc_attr_e( 'Duration: 10 minutes', 'scormcloud' ); ?></div>
+					</div>
+					<p class='inputs'><?php esc_attr_e( 'My name is', 'scormcloud' ); ?> <input
+								disabled name="scormcloudfname" placeholder="First Name" type="text"> <input
+								name="scormcloudlname" disabled placeholder="Last Name"
+								type='text'> <?php esc_attr_e( 'and my email is', 'scormcloud' ); ?>
+						<input name="scormcloudemail" disabled placeholder="Email" type="text">
+						.</p>
+					<input type="button" class="button"
+						   value="<?php esc_attr_e( 'Start Training', 'scormcloud' ); ?>"
+						   onclick="return false;" name="launch"></div>
+			</div>
+
+		</div>
+		<script type="text/javascript" charset="utf-8">
+			var $j = jQuery.noConflict();
+			$j(document).ready(function () {
+
+				$j('#TB_ajaxContent').removeAttr('style');
+				$j('#TB_window').css('overflow-y', 'auto');
+
+				$j('#embedTrainingDialog .toggleButton').toggle(function () {
+					$j($j(this).attr('toggleobject')).fadeIn('slow');
+					$j(this).text($j(this).attr('onText'));
+				}, function () {
+					$j($j(this).attr('toggleobject')).fadeOut('slow');
+					$j(this).text($j(this).attr('offText'));
+				});
+
+				$j('#embedTrainingDialog .courseSelector').change(function () {
+					var selObj = $j('#embedTrainingDialog .courseSelector option:selected');
+					if (selObj.val() != '') {
+						//var newheader = 'Training: ' + selObj.text();
+						//$j('#embedTrainingDialog input[name="trainingHeaderTxt"]').val(newheader);
+						//$j('#embedTrainingDialog .previewDiv h3').text(newheader);
+						$j('#embedTrainingDialog .previewDiv div.courseInfo div.title').text('<?php esc_attr_e( 'Title', 'scormcloud' ); ?>: ' + selObj.text());
+						$j('#embedTrainingDialog .selectOptionsDiv').fadeIn('slow');
+						tb_position();
+					}
+				});
+
+				$j('#embedTrainingDialog input[name="trainingHeaderTxt"]').change(function () {
+					$j('#embedTrainingDialog .previewDiv h3').text($j(this).val());
+				});
+				$j('#embedTrainingDialog textarea[name="trainingDesc"]').change(function () {
+					$j('#embedTrainingDialog p.description').text($j(this).val());
+				});
+				$j('#embedTrainingDialog input[name="trainingRequireLogin"]').change(function () {
+					$j('#embedTrainingDialog .previewDiv p.inputs').toggle();
+				});
+				$j('#embedTrainingDialog input[name="showCourseInfo"]').change(function () {
+					$j('#embedTrainingDialog .previewDiv div.courseInfo').toggle();
+				});
+
+				$j("#embedTrainingDialog .generateTrainingTag").click(function (e) {
+
+
+					var courseId = $j('#embedTrainingDialog .courseSelector option:selected').attr('value');
+					var courseTitle = $j('#embedTrainingDialog .courseSelector option:selected').text();
+					var header = $j('#embedTrainingDialog input[name="trainingHeaderTxt"]').attr('value');
+					var description = $j('#embedTrainingDialog textarea[name="trainingDesc"]').attr('value');
+					var requirelogin = $j('#embedTrainingDialog input[name="trainingRequireLogin"]:checked').length;
+					var showcourseinfo = $j('#embedTrainingDialog input[name="showCourseInfo"]:checked').length;
+
+					$j.ajax({
+						type: "POST",
+						url: "<?php echo esc_url_raw( site_url() . '/wp-content/plugins/scormcloud/ajax.php' ); ?>",
+						data: "action=addPostInvite" +
+						"&courseid=" + courseId +
+						"&coursetitle=" + courseTitle +
+						"&header=" + header +
+						"&description=" + description +
+						"&requirelogin=" + requirelogin +
+						"&showcourseinfo=" + showcourseinfo,
+						success: function (html) {
+							ScormCloud.Dialog.insertTag("[scormcloud.training:" + html + "]");
+						}
+					});
+
+
+				});
+
+
+			});
+
+
+		</script>
+	</div>
+	<?php
 } else {
-    echo "<div>
-            <h2>".__("Please configure your SCORM Cloud settings to add training to your posts.","scormcloud")."</h2>
-        </div>";
-    echo '<div class="settingsPageLink"><a href="'.get_option( 'siteurl' ).'/wp-admin/admin.php?page=scormcloudsettings"
-				title="'.__("Click here to configure your SCORM Cloud plugin.","scormcloud").'">'.__("Click Here to go to the settings page.","scormcloud").'</a></div>';
-
+	echo '<div>
+			<h2>' . esc_attr( __( 'Please configure your SCORM Cloud settings to add training to your posts.', 'scormcloud' ) ) . '</h2>
+		</div>';
+	echo '<div class="settingsPageLink"><a href="' . esc_url_raw( site_url() . '/wp-admin/admin.php?page=scormcloudsettings' ) .
+				'title="' . esc_attr( __( 'Click here to configure your SCORM Cloud plugin.', 'scormcloud' ) ) . '">' . esc_attr( __( 'Click Here to go to the settings page.', 'scormcloud' ) ) . '</a></div>';
 
 
 }

--- a/scormcloud/ui/embedtrainingdialog.php
+++ b/scormcloud/ui/embedtrainingdialog.php
@@ -8,7 +8,6 @@ $wp_path = preg_split( '/(?=((\\\|\/)wp-content)).*/', dirname( __file__ ) );
 $wp_path = ( isset( $wp_path[ 0 ] ) && $wp_path[ 0 ] !== "" ) ? $wp_path[ 0 ] : $_SERVER[ "DOCUMENT_ROOT" ];
 
 /** Load WordPress Administration Bootstrap */
-require_once( $wp_path . $slash . 'wp-load.php' );
 require_once( $wp_path . $slash . 'wp-admin' . $slash . 'admin.php' );
 
 global $wpdb;

--- a/scormcloud/ui/scormcloudcatalogwidget.php
+++ b/scormcloud/ui/scormcloudcatalogwidget.php
@@ -41,7 +41,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 		}
 
 		// Make the widget.
-		wp_enqueue_style( 'scormcloud',  get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/css/scormcloud.widget.css' );
+		wp_enqueue_style( 'scormcloud',  site_url() . '/wp-content/plugins/scormcloud/css/scormcloud.widget.css' );
 
 		global $current_user;
 		global $wpdb;
@@ -99,7 +99,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 						echo "<div class='usercourseblock'>";
 
 						if ( 1 === (int) $reg->active ) {
-							echo "<a class='courseTitle' href='javascript:void(0);' key='" . esc_attr( $reg_id ) . " onclick='ScormCloud.Widget.getLaunchURL(\"" . esc_js( $reg_id ) . "\",\"Catalog\");' url='" . esc_url_raw( get_option( 'siteurl' ) ) . "/wp-content/plugins/scormcloud/ajax.php' title='" . esc_textarea( __( 'Click to launch course ', 'scormcloud' ) ) . esc_textarea( $course_title ) . "'>" . esc_textarea( $course_title ) . '</a>';
+							echo "<a class='courseTitle' href='javascript:void(0);' key='" . esc_attr( $reg_id ) . " onclick='ScormCloud.Widget.getLaunchURL(\"" . esc_js( $reg_id ) . "\",\"Catalog\");' url='" . esc_url_raw( site_url() ) . "/wp-content/plugins/scormcloud/ajax.php' title='" . esc_textarea( __( 'Click to launch course ', 'scormcloud' ) ) . esc_textarea( $course_title ) . "'>" . esc_textarea( $course_title ) . '</a>';
 						} else {
 							echo "<span class='courseTitle' title='" . esc_attr__( 'This course is currently inactive.', 'scormcloud' ) . "'>" . esc_attr( $course_title ) . '</span>';
 						}
@@ -122,7 +122,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 					} else {
 						echo "<div class='usercourseblock'>";
 						if ( $remaining_registrations > 0 ) {
-							echo "<a class='courseTitle' href='javascript:void(0);' coursetitle='" . esc_attr( $course_title ) . "' key='" . esc_attr( $course_id ) . "' onclick='ScormCloud.Widget.getCatalogLaunchURL(\"" . esc_attr( $course_id ) . "\");' url='" . esc_url_raw( get_option( 'siteurl' ) ) . "/wp-content/plugins/scormcloud/ajax.php' title='" . esc_attr__( 'Click to launch course ', 'scormcloud' ) . esc_attr( $course_title ) . "'>" . esc_attr( $course_title ) . '</a>';
+							echo "<a class='courseTitle' href='javascript:void(0);' coursetitle='" . esc_attr( $course_title ) . "' key='" . esc_attr( $course_id ) . "' onclick='ScormCloud.Widget.getCatalogLaunchURL(\"" . esc_attr( $course_id ) . "\");' url='" . esc_url_raw( site_url() ) . "/wp-content/plugins/scormcloud/ajax.php' title='" . esc_attr__( 'Click to launch course ', 'scormcloud' ) . esc_attr( $course_title ) . "'>" . esc_attr( $course_title ) . '</a>';
 						} else {
 							echo "<span class='courseTitle' title='" . esc_attr__( 'This course is currently inactive.', 'scormcloud' ) . "'>" . esc_attr( $course_title ) . '</span>';
 						}
@@ -135,7 +135,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 						echo "<div class='anonlaunchdiv' key='" . esc_attr( $course_id ) . "'>" . esc_attr__( 'First Name', 'scormcloud' ) . ":<br/><input name='scormcloudfname' type='text' key='" . esc_attr( $course_id ) . "'/><br/>";
 						echo esc_attr__( 'Last Name', 'scormcloud' ) . ":<br/><input name='scormcloudlname' type='text' key='" . esc_attr( $course_id ) . "'/><br/>";
 						echo esc_attr__( 'Email', 'scormcloud' ) . ":<br/><input name='scormcloudemail' type='text' key='" . esc_attr( $course_id ) . "'/>";
-						echo "<input name='launch' type='button' class='catalogLaunchBtn' key='" . esc_attr( $course_id ) . "' coursetitle='" . esc_attr( $course_title ) . "' onclick='ScormCloud.Widget.getAnonCatalogLaunchURL(\"" . esc_attr( $course_id ) . "\");' url='" . esc_url_raw( get_option( 'siteurl' ) ) . "/wp-content/plugins/scormcloud/ajax.php' value='" . esc_attr__( 'Start Training', 'scormcloud' ) . "'/>";
+						echo "<input name='launch' type='button' class='catalogLaunchBtn' key='" . esc_attr( $course_id ) . "' coursetitle='" . esc_attr( $course_title ) . "' onclick='ScormCloud.Widget.getAnonCatalogLaunchURL(\"" . esc_attr( $course_id ) . "\");' url='" . esc_url_raw( site_url() ) . "/wp-content/plugins/scormcloud/ajax.php' value='" . esc_attr__( 'Start Training', 'scormcloud' ) . "'/>";
 						echo "<div class='launchMessage'>message</div></div>";
 					} else {
 						echo "<span class='courseTitle' title='" . esc_attr__( 'This course is currently inactive.', 'scormcloud' ) . "'>" . esc_attr( $course_title ) . '</span>';
@@ -144,7 +144,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 				echo '</div>';
 			}// End foreach().
 			echo '</div>';
-			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/scormcloud/scripts/scormcloud.widget.js',  __FILE__ ) );
+			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/../scripts/scormcloud.widget.js',  __FILE__ ) );
 		}// End if().
 		// After the widget.
 		echo wp_kses_post( $args['after_widget'] );

--- a/scormcloud/ui/scormcloudcatalogwidget.php
+++ b/scormcloud/ui/scormcloudcatalogwidget.php
@@ -144,7 +144,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
 				echo '</div>';
 			}// End foreach().
 			echo '</div>';
-			wp_enqueue_script( get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/scripts/scormcloud.widget.js' );
+			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/scormcloud/scripts/scormcloud.widget.js',  __FILE__ ) );
 		}// End if().
 		// After the widget.
 		echo wp_kses_post( $args['after_widget'] );

--- a/scormcloud/ui/scormcloudregistrationswidget.php
+++ b/scormcloud/ui/scormcloudregistrationswidget.php
@@ -113,7 +113,7 @@ class ScormCloudRegistrationsWidget extends WP_Widget {
 				}// End try().
 			}// End foreach().
 			echo '</div>';
-			wp_enqueue_script( 'scormcloudwidget', get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/scripts/scormcloud.widget.js' );
+			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/scormcloud/scripts/scormcloud.widget.js',  __FILE__ ) );
 		}// End if().
 		// After the widget.
 		echo wp_kses_post( $args['after_widget'] );

--- a/scormcloud/ui/scormcloudregistrationswidget.php
+++ b/scormcloud/ui/scormcloudregistrationswidget.php
@@ -38,7 +38,7 @@ class ScormCloudRegistrationsWidget extends WP_Widget {
 		}
 
 		// Make the widget.
-		wp_enqueue_style( 'scormcloud', get_option( 'siteurl' ) . '/wp-content/plugins/scormcloud/css/scormcloud.widget.css' );
+		wp_enqueue_style( 'scormcloud', site_url() . '/wp-content/plugins/scormcloud/css/scormcloud.widget.css' );
 
 		global $current_user;
 		global $wpdb;
@@ -85,7 +85,7 @@ class ScormCloudRegistrationsWidget extends WP_Widget {
 						$course_title = $reg->course_title;
 						echo "<div class='usercourseblock'>";
 						if ( 1 === (int) $reg->active ) {
-							echo  "<a class='courseTitle' href='javascript:void(0);' key='" . esc_attr( $reg_id ) . "' onclick='ScormCloud.Widget.getLaunchURL(\"" . esc_textarea( $reg_id ) . "\",\"Training\");' url='" . esc_url_raw( get_option( 'siteurl' ) ) . "/wp-content/plugins/scormcloud/ajax.php' title='Click to launch course " . esc_textarea( $course_title ) . "'>" . esc_textarea( $course_title ) . '</a>' ;
+							echo  "<a class='courseTitle' href='javascript:void(0);' key='" . esc_attr( $reg_id ) . "' onclick='ScormCloud.Widget.getLaunchURL(\"" . esc_textarea( $reg_id ) . "\",\"Training\");' url='" . esc_url_raw( site_url() ) . "/wp-content/plugins/scormcloud/ajax.php' title='Click to launch course " . esc_textarea( $course_title ) . "'>" . esc_textarea( $course_title ) . '</a>' ;
 						} else {
 							echo  '<span class="courseTitle" title="' . esc_attr__( 'This course is currently inactive.', 'scormcloud' ) . '">' . esc_attr( $course_title ) . '</span>';
 						}
@@ -113,7 +113,7 @@ class ScormCloudRegistrationsWidget extends WP_Widget {
 				}// End try().
 			}// End foreach().
 			echo '</div>';
-			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/scormcloud/scripts/scormcloud.widget.js',  __FILE__ ) );
+			wp_enqueue_script( 'scormcloud-widget' , plugins_url( '/../scripts/scormcloud.widget.js',  __FILE__ ) );
 		}// End if().
 		// After the widget.
 		echo wp_kses_post( $args['after_widget'] );

--- a/scormcloud/uploadpif.php
+++ b/scormcloud/uploadpif.php
@@ -1,58 +1,51 @@
 <?php
 global $wpdb;
 
-if ( defined('ABSPATH') )
-require_once(ABSPATH . 'wp-load.php');
-else
-require_once('../../../wp-load.php');
-require_once(ABSPATH . 'wp-admin/includes/admin.php');
+if ( defined( 'ABSPATH' ) ) {
+	require_once( ABSPATH . 'wp-load.php' );
+} else {
+	require_once( '../../../wp-load.php' );
+}
+require_once( ABSPATH . 'wp-admin/includes/admin.php' );
 
-require_once(SCORMCLOUD_BASE.'scormcloudplugin.php');;
-$ScormService = ScormCloudPlugin::get_cloud_service();
+require_once( SCORMCLOUD_BASE . 'scormcloudplugin.php' );;
+$scorm_service = ScormCloudPlugin::get_cloud_service();
 
 
-$id = $_GET['id'];
-$mode = isset($_GET['mode']) ? $_GET['mode'] : 'new';
+$id   = $_GET[ 'id' ];
+$mode = isset( $_GET[ 'mode' ] ) ? $_GET[ 'mode' ] : 'new';
 
-wp_enqueue_script("jquery");
-
-wp_enqueue_style("global");
-wp_enqueue_style("wp-admin");
-wp_register_style('scormcloud-admin-style', plugins_url('/scormcloud/css/scormcloud.admin.css'));
-wp_enqueue_style('scormcloud-admin-style');
-wp_print_styles();
-
-$uploadService = $ScormService->getUploadService();
+$upload_service = $scorm_service->getUploadService();
 
 //echo $uploadService->GetUploadLink($CFG->wwwroot.'/mod/scormcloud/importcallback.php?courseid='.$id);
 /*** check for https ***/
-$protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http';
+$protocol = isset( $_SERVER[ 'HTTPS' ] ) && $_SERVER[ 'HTTPS' ] === 'on' ? 'https' : 'http';
 /*** return the full address ***/
-$basepath = $protocol.'://'.$_SERVER['HTTP_HOST'].substr($_SERVER['REQUEST_URI'],0,strpos($_SERVER['REQUEST_URI'],'scormcloud')).'scormcloud/';
-$importcallback = $basepath.'/importcallback.php';
+$basepath       = $protocol . '://' . $_SERVER[ 'HTTP_HOST' ] . substr( $_SERVER[ 'REQUEST_URI' ], 0, strpos( $_SERVER[ 'REQUEST_URI' ], 'scormcloud' ) ) . 'scormcloud/';
+$import_callback = $basepath . '/importcallback.php';
 
 echo '<table >';
 
 echo '<tr><td >';
-echo '<form id="uploadform" action="'.$uploadService->GetUploadLink($importcallback.'?courseid='.$id.'&mode='.$mode).'" method="post" ';
+echo '<form id="uploadform" action="' . $upload_service->GetUploadLink( $import_callback . '?courseid=' . $id . '&mode=' . $mode ) . '" method="post" ';
 echo 'enctype="multipart/form-data">';
-echo '<label for="file">'.__("Filename:","scormcloud").'</label>';
+echo '<label for="file">' . __( "Filename:", "scormcloud" ) . '</label>';
 echo '<input type="file" name="filedata" id="file" /> ';
-echo '<input type="submit" id="submit" name="submit" value="'.__("Submit","scormcloud").'" />';
-echo '<span class="importMessage hidden">'.__("Importing Package......","scormcloud").'</span>';
+echo '<input type="submit" id="submit" name="submit" value="' . __( "Submit", "scormcloud" ) . '" />';
+echo '<span class="importMessage hidden">' . __( "Importing Package......", "scormcloud" ) . '</span>';
 echo '</form>';
 echo '</td></tr>';
 echo '</table>';
 
 ?>
 <script
-	type="text/javascript"
-	src='http://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js'></script>
+		type="text/javascript"
+		src='https://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js'></script>
 <script type="text/javascript">
-        
-        jQuery("#uploadform").submit(function(){
-            if (jQuery("#uploadform input[name='filedata']").val().length == 0) return false;
-            jQuery("input[type=submit]", this).attr("disabled", "disabled");
-            jQuery(".importMessage").removeClass('hidden');
-        });
-	</script>
+
+	jQuery("#uploadform").submit(function () {
+		if (jQuery("#uploadform input[name='filedata']").val().length == 0) return false;
+		jQuery("input[type=submit]", this).attr("disabled", "disabled");
+		jQuery(".importMessage").removeClass('hidden');
+	});
+</script>


### PR DESCRIPTION
This PR cleans up our enqueue calls, so that it uses paths relative to the plugin directories (which vary by installation).

I also cleaned up the http/https schema being used for javascript/css includes. We should match whatever is being used for the plugin includes, and external includes now use https.

[CLOUD-901]

