### PR TITLE
Fixes Learner Update for v2 API.

### DIFF
--- a/scormcloud/SCORMCloud_PHPLibrary/ScormEngineService2.php
+++ b/scormcloud/SCORMCloud_PHPLibrary/ScormEngineService2.php
@@ -47,6 +47,7 @@ require_once 'v2/Api/ReportingApi.php';
 require_once 'v2/Api/PingApi.php';
 require_once 'v2/Api/DispatchApi.php';
 require_once 'v2/Api/XapiApi.php';
+require_once 'v2/Api/LearnerApi.php';
 
 require_once 'v2/Model/ModelInterface.php';
 require_once 'v2/Model/PingSchema.php';
@@ -86,6 +87,7 @@ class ScormEngineService
     private $_dispatchService = null;
     private $_invitationService = null;
     private $_lrsAccountService = null;
+    private $_learnerService = null;
 
     public function __construct($scormEngineServiceUrl, $appId, $securityKey, $originString, $proxy = null)
     {
@@ -101,6 +103,7 @@ class ScormEngineService
         $this->_dispatchService = new RusticiSoftware\Cloud\V2\Api\DispatchApi(null, $this->_configuration, null);
         $this->_invitationService = new RusticiSoftware\Cloud\V2\Api\InvitationsApi(null, $this->_configuration, null);
         $this->_lrsAccountService = new RusticiSoftware\Cloud\V2\Api\XapiApi(null, $this->_configuration, null);
+        $this->_learnerService = new RusticiSoftware\Cloud\V2\Api\LearnerApi(null, $this->_configuration, null);
     }
 
     public function isValidAccount()
@@ -230,6 +233,17 @@ class ScormEngineService
     {
         return $this->_lrsAccountService;
     }
+
+    /**
+     * <summary>
+     * Contains SCORM Engine Learner functionality.
+     * </summary>
+     */
+    public function getLearnerService()
+    {
+        return $this->_learnerService;
+    }
+
 
     /**
      * <summary>

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -159,7 +159,7 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Original Release.
 
 == Upgrade Notice ==
-= 2.0.0 =
+= 2.0.1 =
 * Fixes bug with updating Learner info.
 
 = 2.0.0 =

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -3,7 +3,7 @@ Contributors: troyef, stuartchilds, timedwards, brianrogers
 Tags: elearning, learning, scorm, aicc, education, training, cloud
 Requires at least: 4.3
 Tested up to: 5.8
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 
 Tap the power of SCORM to deliver and track training right from your WordPress-powered site.
 
@@ -48,6 +48,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.1 =
+* Fixes bug with updating Learner info.
+
 = 2.0.0 =
 * Update to SCORM Cloud API v2.
 
@@ -156,6 +159,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Original Release.
 
 == Upgrade Notice ==
+= 2.0.0 =
+* Fixes bug with updating Learner info.
+
 = 2.0.0 =
 * Updates to v2 Cloud API
 * Updates Upload process

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.0
+Version: 2.0.1
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -211,14 +211,23 @@ class ScormCloudContentHandler {
 	public static function update_learner_info( $user_id ) {
 		global $wpdb;
 		$cloud_service = ScormCloudPlugin::get_cloud_service();
-		$registration_service   = $cloud_service->getRegistrationService();
+		$learner_service   = $cloud_service->getLearnerService();
 		$user_data     = get_userdata( $user_id );
 		/* pushing blank data into SCORMCloud generates a stack trace */
 		if ( ! empty( $user_data->user_firstname ) &&
 		     ! empty( $user_data->user_lastname )
 		) {
-			$response = $registration_service->UpdateLearnerInfo( $user_data->user_email, $user_data->user_firstname, $user_data->user_lastname );
-			write_log( $response );
+			$learner_schema = new \RusticiSoftware\Cloud\v2\Model\LearnerSchema();
+            $learner_schema->setId($user_data->user_email);
+            $learner_schema->setEmail($user_data->user_email);
+            $learner_schema->setFirstName($user_first_name);
+            $learner_schema->setLastName($user_last_name);
+			try {
+				$response = $learner_service->updateLearnerInfo( $user_data->user_email, $learner_schema );
+			} catch (Exception $ex) {
+				// Ignore this since we don't really mind if cloud is updated if the ID isn't found.
+				// Wordpress will still be updated either way
+			}
 		} else {
 			write_log( "profile update skipped for {$user_data->user_email} due to missing first or last name" );
 		}

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -95,7 +95,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.0' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.1' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';


### PR DESCRIPTION
There was a bug in the previous release that didn't account for the change in the learner API moving to its own object. This update changes that and also adds some error handling in case the user has been deleted from Cloud and is not found with the update call.