### PR TITLE
Fixes security issue with upload and limits filetypes accepted

### DIFF
--- a/scormcloud/admin/file_upload_parser.php
+++ b/scormcloud/admin/file_upload_parser.php
@@ -21,11 +21,10 @@ if(!is_dir($uploadDirectoryName)){
     mkdir($uploadDirectoryName, 0755);
 }
 
-$token = filter_input(INPUT_POST, 'token', FILTER_SANITIZE_STRING);
-
+$token = $_POST["token"];
 if (!$token || $token !== $_SESSION['token']) {
     // show an error message
-    echo '<p class="error">Error: invalid form submission</p>';
+    echo '<p class="error">Error: invalid form submission </p>';
     // return 405 http status code
     header($_SERVER['SERVER_PROTOCOL'] . ' 405 Method Not Allowed');
     exit;

--- a/scormcloud/admin/file_upload_parser.php
+++ b/scormcloud/admin/file_upload_parser.php
@@ -21,6 +21,16 @@ if(!is_dir($uploadDirectoryName)){
     mkdir($uploadDirectoryName, 0755);
 }
 
+$token = filter_input(INPUT_POST, 'token', FILTER_SANITIZE_STRING);
+
+if (!$token || $token !== $_SESSION['token']) {
+    // show an error message
+    echo '<p class="error">Error: invalid form submission</p>';
+    // return 405 http status code
+    header($_SERVER['SERVER_PROTOCOL'] . ' 405 Method Not Allowed');
+    exit;
+}
+
 $fileName = $_FILES["file1"]["name"]; // The file name
 $fileTmpLoc = $_FILES["file1"]["tmp_name"]; // File in the PHP tmp folder
 $fileType = $_FILES["file1"]["type"]; // The type of file it is

--- a/scormcloud/admin/uploadpif.php
+++ b/scormcloud/admin/uploadpif.php
@@ -24,6 +24,8 @@ $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : '
 $basepath = $protocol . '://' . $_SERVER['HTTP_HOST'] . substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], 'scormcloud')) . 'scormcloud/';
 $import_callback = $basepath . '/importcallback.php';
 
+$_SESSION['token'] = bin2hex(random_bytes(35));
+
 ?>
 <link rel="stylesheet" href="../css/scormcloud.admin.css" />
 <script>
@@ -66,10 +68,11 @@ function abortHandler(event){
 		<td>
 			<form id="upload_form" enctype="multipart/form-data" method="post">
 				<h5>Choose ZIP/MP3/MP4/PDF File</h5>
-				<input type="file" name="file1" id="file1" ><br>
+				<input type="file" name="file1" id="file1" accept="application/zip, video/mp4, audio/mp3, application/pdf"><br>
 				<input type="button" id="submit" value="Upload File" onclick="uploadFile()">
 				<input type="hidden" value="<?=$id?>" name="courseId" id="courseId">
 				<span class="importMessage" style="display:none;"><?=__("Importing Package......", "scormcloud")?></span>
+				<input type="hidden" name="token" value="<?= $_SESSION['token'] ?? '' ?>">
 				<h3 id="status"></h3>
 				<p id="loaded_n_total"></p>
 			</form>

--- a/scormcloud/admin/uploadpif.php
+++ b/scormcloud/admin/uploadpif.php
@@ -8,8 +8,6 @@ if (defined('ABSPATH')) {
 }
 require_once ABSPATH . 'wp-admin/includes/admin.php';
 
-// define( 'SCORMCLOUD_BASE', '../' );
-
 require_once SCORMCLOUD_BASE . 'scormcloudplugin.php';
 $scorm_service = ScormCloudPlugin::get_cloud_service();
 
@@ -38,6 +36,7 @@ function uploadFile(){
 	var formdata = new FormData();
 	formdata.append("file1", file);
 	formdata.append("courseid", "<?=$id?>");
+	formdata.append("token", "<?= $_SESSION['token'] ?? '' ?>");
 	var ajax = new XMLHttpRequest();
 	ajax.upload.addEventListener("progress", progressHandler, false);
 	ajax.addEventListener("load", completeHandler, false);

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -3,7 +3,7 @@ Contributors: troyef, stuartchilds, timedwards, brianrogers
 Tags: elearning, learning, scorm, aicc, education, training, cloud
 Requires at least: 4.3
 Tested up to: 5.8
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 
 Tap the power of SCORM to deliver and track training right from your WordPress-powered site.
 
@@ -48,6 +48,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.2 =
+* Fixes security issues with upload form.
+
 = 2.0.1 =
 * Fixes bug with updating Learner info.
 
@@ -56,6 +59,7 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 = 1.2.3 =
 * Fixed bug in course catalog widget
+* Final update for v1 API
 
 = 1.2.2 =
 * Fixed bug in anonymous registrations
@@ -159,6 +163,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Original Release.
 
 == Upgrade Notice ==
+= 2.0.2 =
+* Fixes security issues with upload form.
+
 = 2.0.1 =
 * Fixes bug with updating Learner info.
 
@@ -171,6 +178,7 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Updates Training View
 * Updates to synching learner information
 * Updates to shortcode management
+* Last update with v1 API
 
 = 1.1.8 =
 * Adding proxy support

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.1
+Version: 2.0.2
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -232,4 +232,11 @@ class ScormCloudContentHandler {
 			write_log( "profile update skipped for {$user_data->user_email} due to missing first or last name" );
 		}
 	}
+
+	/**
+	 * Make sure the session is started and available
+	 */
+	public static function boot_session() {
+		session_start();
+	}
 }

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -95,7 +95,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.1' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.2' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -46,8 +46,10 @@ class ScormCloudPlugin {
 
 		add_action( 'save_post', array( 'ScormCloudContentHandler', 'update_post_invite' ) );
 		add_action( 'profile_update', array( 'ScormCloudContentHandler', 'update_learner_info' ) );
+		
+		add_action('wp_loaded',array( 'ScormCloudContentHandler','boot_session'));
 	}
-
+	  
 	/**
 	 * Check for updates.
 	 */


### PR DESCRIPTION
Per the recent security report on the plug-in, we are now checking file type inputs as well as implementing a simple CSRF token check for the upload page processor to limit the possibility of malicious file upload.