### PR TITLE
Allow unlimited accounts to create Registrations

### DIFF
--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -3,7 +3,7 @@ Contributors: troyef, stuartchilds, timedwards, brianrogers
 Tags: elearning, learning, scorm, aicc, education, training, cloud
 Requires at least: 4.3
 Tested up to: 5.8
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 
 Tap the power of SCORM to deliver and track training right from your WordPress-powered site.
 
@@ -48,6 +48,10 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.3 =
+* Removes potentially bad logging call
+* Allows for accounts with unlimited Registrations
+
 = 2.0.2 =
 * Fixes security issues with upload form.
 
@@ -163,6 +167,10 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Original Release.
 
 == Upgrade Notice ==
+= 2.0.3 =
+* Removes potentially bad logging call
+* Allows for accounts with unlimited Registrations
+
 = 2.0.2 =
 * Fixes security issues with upload form.
 

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.2
+Version: 2.0.3
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -228,9 +228,7 @@ class ScormCloudContentHandler {
 				// Ignore this since we don't really mind if cloud is updated if the ID isn't found.
 				// Wordpress will still be updated either way
 			}
-		} else {
-			write_log( "profile update skipped for {$user_data->user_email} due to missing first or last name" );
-		}
+		} 
 	}
 
 	/**

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -97,7 +97,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.2' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.3' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';
@@ -133,6 +133,10 @@ class ScormCloudPlugin {
 			return 1;
 		} else {
 			$reg_limit = (int) $account_info->regLimit;
+			if ( $reg_limit == -1 ){
+				//unlimited account
+				return 999;
+			}
 			$reg_usage = (int) $account_info->usage->regCount;
 			return $reg_limit - $reg_usage;
 		}


### PR DESCRIPTION
There was a bug where if we got a RegLimit of `-1` for an unlimited account, then it wasn't handled properly and fails to allow new Registrations to be created. This allows for unlimited accounts now.