### PR TITLE
Post Results fix

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -110,7 +110,7 @@ class ScormCloudContentHandler {
 								$completion = (string) $registration_result->getRegistrationCompletion();
 								$success    = (string) $registration_result->getRegistrationSuccess();
 								$seconds    = $registration_result->getTotalSecondsTracked();
-								$score      = $registration_result->getScore();
+								$score      = $registration_result->getScore()->getScaled();
 
 								$invite_html .= '<table class="result_table"><tr>' .
 											'<td class="head">' . __( 'Completion', 'scormcloud' ) . '</td>' .

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -107,10 +107,10 @@ class ScormCloudContentHandler {
 							if (ScormCloudPlugin::registration_exists($reg_id)){
 								$registration_result = $registration_service->getRegistrationProgress($reg_id);
 
-								$completion = (string) $registration_result->registrationCompletion;
-								$success    = (string) $registration_result->registrationSuccess;
-								$seconds    = $registration_result->totalSecondsTracked;
-								$score      = $registration_result->score;
+								$completion = (string) $registration_result->getRegistrationCompletion();
+								$success    = (string) $registration_result->getRegistrationSuccess();
+								$seconds    = $registration_result->getTotalSecondsTracked();
+								$score      = $registration_result->getScore();
 
 								$invite_html .= '<table class="result_table"><tr>' .
 											'<td class="head">' . __( 'Completion', 'scormcloud' ) . '</td>' .


### PR DESCRIPTION
Fixes an issue where registration results were not being displayed in posts after taking training because appropriate getter methods were not being used. 

Now, the Completion, Success, Score, and Total Time display correctly in WP posts.

<img width="1006" alt="Screen Shot 2022-09-15 at 4 35 21 PM" src="https://user-images.githubusercontent.com/81175961/190513594-f2ee9666-e711-4167-91b1-38755f752a0b.png">
