### PR TITLE
Undefined Score Fix

### DIFF
--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -48,6 +48,12 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.6 =
+Fixes an issue displaying results when registration score is undefined / null
+
+= 2.0.5 =
+Fixes a bug displaying training results in posts
+
 = 2.0.4 =
 * Updates 3rd party libraries
 * Adds dependency on SCORM Cloud v2 API client library
@@ -173,6 +179,12 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 * Original Release.
 
 == Upgrade Notice ==
+= 2.0.6 =
+Fixes an issue displaying results when registration score is undefined / null
+
+= 2.0.5 =
+Fixes a bug displaying training results in posts
+
 = 2.0.4 =
 * Updates to third party libraries
 * Fixes bugs from missing require statements: PHP Fatal error: Uncaught Error: Class '\RusticiSoftware\Cloud\V2\Model\...' not found in .../ObjectSerializer.php:299

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.4
+Version: 2.0.6 
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -110,7 +110,7 @@ class ScormCloudContentHandler {
 								$completion = (string) $registration_result->getRegistrationCompletion();
 								$success    = (string) $registration_result->getRegistrationSuccess();
 								$seconds    = $registration_result->getTotalSecondsTracked();
-								$score      = $registration_result->getScore()->getScaled();
+								$score      = is_null($registration_result->getScore()) ? 'unknown' : $registration_result->getScore()->getScaled();
 
 								$invite_html .= '<table class="result_table"><tr>' .
 											'<td class="head">' . __( 'Completion', 'scormcloud' ) . '</td>' .

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -97,7 +97,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.4' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.6' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';


### PR DESCRIPTION
Fixes an issue with posts when trying to display score when a registration's score is undefined and returns null.

No score returned:

<img width="697" alt="Screen Shot 2022-09-22 at 5 47 04 PM" src="https://user-images.githubusercontent.com/81175961/191864551-f55c705a-e0d8-4b9c-8876-6dcebd83d72c.png">

Score returned:
<img width="695" alt="Screen Shot 2022-09-22 at 5 55 16 PM" src="https://user-images.githubusercontent.com/81175961/191865417-aba65fb1-0e67-4f51-a560-9b52eab5d50c.png">

