### PR TITLE
Fixes critical error when loading training details page

### DIFF
--- a/scormcloud/admin/trainingdetails.php
+++ b/scormcloud/admin/trainingdetails.php
@@ -1,5 +1,5 @@
 <?php
-require_once('vendor/autoload.php');
+require_once SCORMCLOUD_BASE . 'vendor/autoload.php';
 
 require_once SCORMCLOUD_BASE . 'scormcloudplugin.php';
 require_once SCORMCLOUD_BASE . 'db/scormclouddatabase.php';

--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -48,6 +48,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.7 =
+Fixes an issue loading the training details page
+
 = 2.0.6 =
 Fixes an issue displaying results when registration score is undefined / null
 
@@ -179,6 +182,9 @@ Fixes a bug displaying training results in posts
 * Original Release.
 
 == Upgrade Notice ==
+= 2.0.7 =
+Fixes an issue loading the training details page
+
 = 2.0.6 =
 Fixes an issue displaying results when registration score is undefined / null
 

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.6 
+Version: 2.0.7
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -97,7 +97,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.6' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.7' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';


### PR DESCRIPTION
Fixes a broken require statement which caused a critical error when loading training details page. Since `trainingdetails.php` lives in the `admin` folder, the `require` statement needed an absolute path to find `vendor/autoload.php`. In other places where we require `autoload.php`, a relative path works just fine (i.e. courseconfig.php & scormcloudcontenthandler.php).