### PR TITLE
Fix: Undefined first and last name when a user updates their user profile

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -221,8 +221,8 @@ class ScormCloudContentHandler {
 			$learner_schema = new \RusticiSoftware\Cloud\V2\Model\LearnerSchema();
             $learner_schema->setId($user_data->user_email);
             $learner_schema->setEmail($user_data->user_email);
-            $learner_schema->setFirstName($user_first_name);
-            $learner_schema->setLastName($user_last_name);
+            $learner_schema->setFirstName($user_data->user_firstname);
+            $learner_schema->setLastName($user_data->user_lastname);
 			try {
 				$response = $learner_service->updateLearnerInfo( $user_data->user_email, $learner_schema );
 			} catch (Exception $ex) {


### PR DESCRIPTION
When a user saves their profile and WP debug is enabled, warnings about undefined variables appear in the debug.log file.

Furthermore, I think this issue might cause the first name and last name to be set to an empty string in SCORM (but I don't have access to our SCROM instance, so I could not check this - it might ignore the empty values).

**Steps to reproduce**

1) Add the following lines to wp-config.php to enable WP debug
```
define('WP_DEBUG', true);
define('WP_DEBUG_DISPLAY', false);
define('WP_DEBUG_LOG', true);
```
2) In the backend go to Users > Profile

3) Make sure the First Name and Last Name fields are not blank

4) Save your user details

**Result:**
The following warnings appears in the /wp-content/debug.log file:
```
[08-Nov-2022 16:03:38 UTC] PHP Notice:  Undefined variable: user_first_name in <webroot>/scormcloud/scormcloudcontenthandler.php on line 225
[08-Nov-2022 16:03:39 UTC] PHP Notice:  Undefined variable: user_last_name in <webroot>/scormcloud/scormcloudcontenthandler.php on line 226
```