### PR TITLE
Fix warnings about undefined 'metadata' variables in debug.log

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -51,9 +51,10 @@ class ScormCloudContentHandler {
 					// get course info.
 					$invite_html .= "<div class='courseInfo'>";
 
+					$metadata = null;
 					if ( $is_valid_account ) {
 						$course_detail = $course_service->GetCourse( $invite->course_id, false, true );
-						if ($course_detail->metadata) {
+						if (isset($course_detail->metadata)) {
 							$metadata    = $course_detail->metadata;
 						}
 					}


### PR DESCRIPTION
When WP debug is enabled, a number of warnings about undefined variables appear in the debug.log file.
However, it might depend on how the course/training is defined in SCORM for these warnings to appear. 

**Steps to reproduce**

1) Add the following lines to wp-config.php to enable WP debug
```
define('WP_DEBUG', true);
define('WP_DEBUG_DISPLAY', false);
define('WP_DEBUG_LOG', true);
```
2) Edit a page (and if you are using the Block Editor, add a Classic block)

3) Use the "Insert a SCORM Cloud training link" button and insert a SCORM Cloud embed code.

4) Publish the page

**Result:**
The following warnings appears in the /wp-content/debug.log file:
```
[08-Nov-2022 15:49:00 UTC] PHP Notice:  Undefined property: RusticiSoftware\Cloud\V2\Model\CourseSchema::$metadata in <webroot>/scormcloud/scormcloudcontenthandler.php on line 56
[08-Nov-2022 15:49:00 UTC] PHP Notice:  Undefined variable: metadata in <webroot>/scormcloud/scormcloudcontenthandler.php on line 62
```