### PR TITLE
Fix debug.log warnings - session already started and headers being already sent

### DIFF
--- a/scormcloud/scormcloudcontenthandler.php
+++ b/scormcloud/scormcloudcontenthandler.php
@@ -236,6 +236,8 @@ class ScormCloudContentHandler {
 	 * Make sure the session is started and available
 	 */
 	public static function boot_session() {
-		session_start();
+		if ( ! session_id() && ! headers_sent() ) {
+			session_start();
+		}
 	}
 }


### PR DESCRIPTION
I have a custom theme that has user logins and related code where I use the PHP session. 
In such a case, the SCORM Cloud plugin causes warnings to be written to the log file when WP debug is enabled. 

**Steps to reproduce**

1) Add the following lines to wp-config.php to enable WP debug
```
define('WP_DEBUG', true);
define('WP_DEBUG_DISPLAY', false);
define('WP_DEBUG_LOG', true);
```
2) Add the following lines to your theme's functions.php

```
function theme_start_session() {
	if ( ! session_id() && ! headers_sent() ) {
		session_start();
	}
}
add_action('init', 'theme_start_session');
```
3) Visit any page on the website or in the admin.

4) Also trigger WP cron by visiting "/wp-cron.php?doing_wp_cron=1667920617.6225979328155517578125"

5) Check /wp-content/debug.log

**Result:**
The following warnings appears in the log file:

```
[08-Nov-2022 15:23:57 UTC] PHP Notice:  session_start(): A session had already been started - ignoring in <webroote>/scormcloud/scormcloudcontenthandler.php on line 239
[08-Nov-2022 15:23:57 UTC] PHP Warning:  Cannot modify header information - headers already sent by (output started at <webroot>/scormcloud/scormcloudcontenthandler.php:239) in <webroot>/wp-includes/pluggable.php on line 1421
```