### PR TITLE
Add <label> elements to checkboxes and radio buttons

### DIFF
--- a/scormcloud/admin/managetraining.php
+++ b/scormcloud/admin/managetraining.php
@@ -69,12 +69,12 @@ $coursesFilter = (ScormCloudPlugin::is_network_managed() && get_site_option('sco
 <table class="learnerSelection">
 	<tr>
 		<td>
-		<div><input type='radio' name='learnerPopulationType' value='allUsers' /><?php _e("All Users", "scormcloud");?></div>
+		<div><label><input type='radio' name='learnerPopulationType' value='allUsers' /><?php _e("All Users", "scormcloud");?></label></div>
 
 		</td>
 		<td>
-		<div><input type='radio' name='learnerPopulationType'
-			value='selectUsers' /><?php _e("Select User(s)", "scormcloud");?></div>
+		<div><label><input type='radio' name='learnerPopulationType'
+			value='selectUsers' /><?php _e("Select User(s)", "scormcloud");?></label></div>
 		<ul class="userHolder selectionHolder"></ul>
 		<?php
 $userArgs = array('show_option_none' => ' ',
@@ -89,8 +89,8 @@ $userArgs = array('show_option_none' => ' ',
 
             ?></td>
 		<td class='lastCol'>
-		<div><input type='radio' name='learnerPopulationType'
-			value='selectRoles' /><?php _e("Select Role(s)", "scormcloud");?></div>
+		<div><label><input type='radio' name='learnerPopulationType'
+			value='selectRoles' /><?php _e("Select Role(s)", "scormcloud");?></label></div>
 		<ul class="roleHolder selectionHolder"></ul>
 		<select class="roleSelector">
 			<option selected value='-1'></option>
@@ -104,7 +104,7 @@ $roleArgs = array();
 	</tr>
 </table>
 
-<p><input name="sendemail" type="checkbox" />Send invitation email to selected user(s)</p>
+<p><label><input name="sendemail" type="checkbox" />Send invitation email to selected user(s)</label></p>
 
 <p><input id="btnAddRegistration" type="button"
 	value="<?php _e("Create Training", "scormcloud");?>" /><span

--- a/scormcloud/admin/network_settings.php
+++ b/scormcloud/admin/network_settings.php
@@ -67,10 +67,10 @@ if(isset($_POST['scormcloud_hidden']) && $_POST['scormcloud_hidden'] == 'Y') {
 <p><?php _e("Secret Key: ","scormcloud" ); ?><input type="text"	name="scormcloud_secretkey" value="<?php echo $secretkey; ?>" size="50"></p>
 
 <h3><?php _e('Network Settings'); ?></h3>
-<p><input type="checkbox" name="scormcloud_networkmanaged" <?php echo ($network_managed ? "checked" : "") ?> />
-    <?php _e('Use same SCORM Cloud account across all sites.', 'scormcloud'); ?></p>
-<p><input type="checkbox" name="scormcloud_sharecourses"<?php echo ($sharecourses ? "checked" : ""); ?> />
-    <?php _e(" Share courses among all sites.","scormcloud" ); ?></p>
+<p><label><input type="checkbox" name="scormcloud_networkmanaged" <?php echo ($network_managed ? "checked" : "") ?> />
+    <?php _e('Use same SCORM Cloud account across all sites.', 'scormcloud'); ?></label></p>
+<p><label><input type="checkbox" name="scormcloud_sharecourses"<?php echo ($sharecourses ? "checked" : ""); ?> />
+    <?php _e(" Share courses among all sites.","scormcloud" ); ?></label></p>
 	
 <h3><?php _e('Advanced Settings'); ?></h3>
 <p><?php _e("Cloud Engine URL: ","scormcloud" ); ?><input type="text"

--- a/scormcloud/admin/trainingdetails.php
+++ b/scormcloud/admin/trainingdetails.php
@@ -58,14 +58,14 @@ if ($invite->active != 2) {
 				<td><textarea type="text" name="trainingDesc"><?php echo $invite->description; ?></textarea></td>
 			</tr>
 			<tr>
-				<td colspan='2'><input type="checkbox"
+				<td colspan='2'><label><input type="checkbox"
 				<?php echo ($invite->require_login == 1 ? "checked" : ""); ?>
-					name="trainingRequireLogin" /><?php _e("Require that learners be authenticated users.", "scormcloud");?></td>
+					name="trainingRequireLogin" /><?php _e("Require that learners be authenticated users.", "scormcloud");?></label></td>
 			</tr>
 			<tr>
-				<td colspan='2'><input type="checkbox"
+				<td colspan='2'><label><input type="checkbox"
 				<?php echo ($invite->show_course_info == 1 ? "checked" : ""); ?>
-					name="showCourseInfo" /><?php _e("Show the course title and description.", "scormcloud");?></td>
+					name="showCourseInfo" /><?php _e("Show the course title and description.", "scormcloud");?></label></td>
 			</tr>
 		</table>
 		<input type="button" class="updateInvitation button"

--- a/scormcloud/ui/embedtrainingdialog.php
+++ b/scormcloud/ui/embedtrainingdialog.php
@@ -61,13 +61,13 @@ if ($is_valid_account) {
 					</td>
 				</tr>
 				<tr>
-					<td colspan='2'><input type="checkbox" checked
-										   name="trainingRequireLogin"/><?php esc_attr_e('Require that learners be authenticated users.', 'scormcloud');?>
+					<td colspan='2'><label><input type="checkbox" checked
+										   name="trainingRequireLogin"/><?php esc_attr_e('Require that learners be authenticated users.', 'scormcloud');?></label>
 					</td>
 				</tr>
 				<tr>
-					<td colspan='2'><input type="checkbox" checked
-										   name="showCourseInfo"/><?php esc_attr_e('Show the course title and description.', 'scormcloud');?>
+					<td colspan='2'><label><input type="checkbox" checked
+										   name="showCourseInfo"/><?php esc_attr_e('Show the course title and description.', 'scormcloud');?></label>
 					</td>
 				</tr>
 


### PR DESCRIPTION
The various forms don't have <label> elements for the input fields.
For checkboxes and radio buttons, this means that you have to click the actual checkbox or radio button. 
With this fix, you'll be able to click the label text next to the radio checkboxes and radio buttons to select them.

I've only fixed this for checkboxes and radio buttons, not for text fields.

Affected areas:
- Network settings
- Manage training (Quick Create Training section)
- Managa training details (Invitation Details section)
- Embed training dialog