### PR TITLE
Catalog widget warnings

### DIFF
--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -193,7 +193,7 @@ class ScormCloudPlugin {
 	/**
 	 * Helper method to get all courses recursively to match v1 functionality
 	 */
-	function loadAllCourses($courseService) {
+	public static function loadAllCourses($courseService) {
 		$courseResponse = $courseService->getCourses(null, null, 'updated', null, null, null, null, null, 'false', 'true');
 		$more = $courseResponse->getMore();
 		$courseArray = $courseResponse->getCourses();
@@ -211,7 +211,7 @@ class ScormCloudPlugin {
 	/**
 	 * Helper method to handle the more courses token
 	 */
-	function handleMoreCourses($more, $courseService) {
+	protected static function handleMoreCourses($more, $courseService) {
 		if ($more != '') {
 			// there are more results to load them up recursively if needed
 			$moreResponse = $courseService->getCourses(null, null, 'updated', null, null, null, null, $more, 'false', 'true');

--- a/scormcloud/ui/scormcloudcatalogwidget.php
+++ b/scormcloud/ui/scormcloudcatalogwidget.php
@@ -84,7 +84,7 @@ class ScormCloudCatalogWidget extends WP_Widget {
                                                                     ON reg.invite_id = inv.invite_id
                                                                 WHERE reg.user_id = %s AND inv.course_id = %s
                                                                 ORDER BY reg.update_date DESC',
-					array( $current_user->ID, $course_id ), OBJECT ));// db call ok; no-cache ok.
+					array( $current_user->ID, $course_id )), OBJECT );// db call ok; no-cache ok.
 
 					if ( null !== $reg ) {
 						$reg_id            = $reg->reg_id;


### PR DESCRIPTION
When using the Scorm Cloud Catalog Widget with WP_DEBUG enabled, warnings will appear in the debug.log file.
This happens because some functions in the ScormCloudPlugin class are not marked static.
Also, a warning about wpdb->prepare being used incorrectly appears.

**Steps to reproduce**

1) Add the following lines to wp-config.php to enable WP debug
```
define('WP_DEBUG', true);
define('WP_DEBUG_DISPLAY', false);
define('WP_DEBUG_LOG', true);
```
2) Add the "Scorm Cloud Catalog Widget" to a sidebar or footer area

3) Open the website

**Result:**
The following warnings appears in the log file:

```
[09-Nov-2022 08:48:11 UTC] PHP Deprecated:  Non-static method ScormCloudPlugin::loadAllCourses() should not be called statically in <webroot>/scormcloud/ui/scormcloudcatalogwidget.php on line 53
[09-Nov-2022 08:48:11 UTC] PHP Notice:  Function wpdb::prepare was called <strong>incorrectly</strong>. Unsupported value type (array). Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 4.8.2.) in <webroot>/wp-includes/functions.php on line 5831
```

PS: The problem with the wpdb->prepare() call is that OBJECT was passed as a 3rd parameter to the function. Instead, OBJECT should be passed to the wpdb->get_row() call.