### PR TITLE
V2.0.8

### DIFF
--- a/scormcloud/readme.txt
+++ b/scormcloud/readme.txt
@@ -48,6 +48,9 @@ The SCORM Cloud For WordPress basic functionality works with BuddyPress without 
 
 
 == Changelog ==
+= 2.0.8 =
+Fixes an issue determining whether an account has a strict registration limit
+
 = 2.0.7 =
 Fixes an issue loading the training details page
 

--- a/scormcloud/scormcloud.php
+++ b/scormcloud/scormcloud.php
@@ -4,7 +4,7 @@ Plugin Name: SCORM Cloud For WordPress
 Plugin URI: http://scorm.com/wordpress
 Description: Tap the power of SCORM to deliver and track training right from your WordPress-powered site. Just add the SCORM Cloud widget to the sidebar or use the SCORM Cloud button to add a link directly in a post or page.
 Author: Rustici Software
-Version: 2.0.7
+Version: 2.0.8
 Author URI: http://www.scorm.com
  */
 

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -97,7 +97,7 @@ class ScormCloudPlugin {
 			$proxy      = get_option( 'proxy' );
 		}
 
-		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.7' );
+		$origin = ScormEngineUtilities::getCanonicalOriginString( 'Rustici Software', 'WordPress', '2.0.8' );
 
 		if ( strlen( $engine_url ) < 1 ) {
 			$engine_url = 'https://cloud.scorm.com/api/v2';

--- a/scormcloud/scormcloudplugin.php
+++ b/scormcloud/scormcloudplugin.php
@@ -129,7 +129,7 @@ class ScormCloudPlugin {
 		$response     = $account_service->GetAccountInfo(); 
 		
 		$account_info = json_decode($response);
-		if ( 'trial' !== (string) $account_info->accountType && 'false' === (string) $account_info->strictLimit ) {
+		if ( 'trial' !== (string) $account_info->accountType && !$account_info->strictLimit ) {
 			return 1;
 		} else {
 			$reg_limit = (int) $account_info->regLimit;


### PR DESCRIPTION
Fixes an issue stemming from parsing account info and casting `strictLimit` to a string for comparison. This was preventing users from creating new registrations after reaching their registration limit even when `strictLimit` was `false`.